### PR TITLE
Replace copy.deepcopy with something faster

### DIFF
--- a/src/snovault/embed.py
+++ b/src/snovault/embed.py
@@ -1,6 +1,5 @@
-from copy import deepcopy
 from .cache import ManagerLRUCache
-from past.builtins import basestring
+from .util import quick_deepcopy
 from posixpath import join
 from pyramid.compat import (
     native_,
@@ -65,7 +64,7 @@ def embed(request, *elements, **kw):
             cached = _embed(request, path)
             embed_cache[path] = cached
         result, embedded, linked = cached
-        result = deepcopy(result)
+        result = quick_deepcopy(result)
     request._embedded_uuids.update(embedded)
     request._linked_uuids.update(linked)
     return result

--- a/src/snovault/resources.py
+++ b/src/snovault/resources.py
@@ -1,7 +1,6 @@
 # See http://docs.pylonsproject.org/projects/pyramid/en/latest/narr/resources.html
 import logging
 from collections import Mapping
-from copy import deepcopy
 from pyramid.decorator import reify
 from pyramid.httpexceptions import HTTPInternalServerError
 from pyramid.security import (
@@ -23,6 +22,7 @@ from .interfaces import (
 from .validation import ValidationFailure
 from .util import (
     ensurelist,
+    quick_deepcopy,
     simple_path_ids,
 )
 
@@ -268,7 +268,7 @@ class Item(Resource):
         }
 
     def upgrade_properties(self):
-        properties = deepcopy(self.properties)
+        properties = quick_deepcopy(self.properties)
         current_version = properties.get('schema_version', '')
         target_version = self.type_info.schema_version
         if target_version is not None and current_version != target_version:

--- a/src/snovault/util.py
+++ b/src/snovault/util.py
@@ -67,3 +67,19 @@ def select_distinct_values(request, value_path, *from_paths):
         values = {value for value_list in value_lists for value in value_list}
 
     return list(values)
+
+
+def quick_deepcopy(obj):
+    """Deep copy an object consisting of dicts, lists, and primitives.
+
+    This is faster than Python's `copy.deepcopy` because it doesn't
+    do bookkeeping to avoid duplicating objects in a cyclic graph.
+
+    This is intended to work fine for data deserialized from JSON,
+    but won't work for everything.
+    """
+    if isinstance(obj, dict):
+        obj = {k: quick_deepcopy(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        obj = [quick_deepcopy(v) for v in obj]
+    return obj


### PR DESCRIPTION
With this change, indexing an ENCODED demo instance took 6 hours (compared to 7-8 which Ben said is typical)