### PR TITLE
Add ability to specify ports for wsgi test server

### DIFF
--- a/src/snovault/tests/serverfixtures.py
+++ b/src/snovault/tests/serverfixtures.py
@@ -305,10 +305,25 @@ def no_deps(conn, DBSession):
 
     event.remove(session, 'before_flush', check_dependencies)
 
+
 @pytest.fixture(scope='session')
-def wsgi_server_host_port():
-    from webtest.http import get_free_port
-    return get_free_port()
+def wsgi_server_host_port(request):
+    wsgi_args = dict(request.config.option.wsgi_args or ())
+    if (
+        'port_range.min' in wsgi_args and
+        'port_range.max' in wsgi_args
+    ):
+        import random
+        # spin up wsgi server on specific ports if start and end are defined
+        wsgi_args['port_range.min'] = int(wsgi_args['port_range.min'])
+        wsgi_args['port_range.max'] = int(wsgi_args['port_range.max'])
+        port = random.randrange(wsgi_args['port_range.min'],
+                                wsgi_args['port_range.max'])
+        return ('127.0.0.1', port)
+    else:
+        # otherwise get any free port
+        from webtest.http import get_free_port
+        return get_free_port()
 
 
 @pytest.fixture(scope='session')

--- a/src/snowflakes/tests/__init__.py
+++ b/src/snowflakes/tests/__init__.py
@@ -11,3 +11,4 @@ class AppendInt2(argparse._AppendAction):
 def pytest_addoption(parser):
     parser.addoption('--browser-arg', nargs=2, dest='browser_args', action='append', type='string')
     parser.addoption('--browser-arg-int', nargs=2, dest='browser_args', action=AppendInt2, type='string')
+    parser.addoption('--wsgi-arg', nargs=2, dest='wsgi_args', action='append', type='string')


### PR DESCRIPTION
The proposed code modifies the `wsgi_server_host_port` fixture in `serverfixtures.py` so that if two specific arguments are passed to it, it will initiate the WSGI test server in the specified port range. This is useful if your browser tests need to be run on specific ports (eg ClinGen needs to be run on specific ports for testing Auth0 authentication). If the arguments are missing the fixture will default to `webtest.http`'s `get_free_port`method as before.

The extra code was derived from `webtest.http`'s `get_free_port` method, with modifications to make it loop through the specified port range until it finds a free port. If a free port is not found within the range, it will raise an exception.

Testing:
1. Browser tests should run on any open port (default/original behavior):
`bin/test -m bdd -v --splinter-webdriver chrome`

2. Browser tests should run between ports 65525 and 65535:
`bin/test -m bdd -v --splinter-webdriver chrome --wsgi-arg port_range.min 65525 --wsgi-arg port_range.max 65535`

3. Browser tests should fail due to occupied port (assuming port 80 is occupied):
`bin/test -m bdd -v --splinter-webdriver chrome --wsgi-arg port_range.min 80 --wsgi-arg port_range.max 80`

4. Browser tests should run on any open port (default/original behavior because `port_range.max` is missing):
`bin/test -m bdd -v --splinter-webdriver chrome --wsgi-arg port_range.min 65525`


For derivative projects (eg clincoded, encoded) their `tests/__init.py` file will need the additional line in the `pytest_addoption function for the command line arguments to be read properly:
```python
parser.addoption('--wsgi-arg', nargs=2, dest='wsgi_args', action='append', type='string')
```

If the specified ports are also required for travis tests, the arguments must be added to `.travis.yml` as well. An example (see last two lines):
```
    if test -n "$BROWSER"; then
      test -s "$SC_PIDFILE" && sleep 10 && bin/test -v -v --timeout=600 -m "bdd" --tb=short \
        --splinter-implicit-wait 60 \
        --splinter-webdriver remote \
        --splinter-remote-url "http://$SAUCE_USERNAME:$SAUCE_ACCESS_KEY@localhost:4445/wd/hub" \
        --splinter-socket-timeout 600 \
        --browser-arg tunnel-identifier "$TRAVIS_JOB_NUMBER" \
        --browser-arg-int build  "$TRAVIS_BUILD_NUMBER" \
        --browser-arg-int idleTimeout 600 \
        --browser-arg name "$TRAVIS_REPO_SLUG $TRAVIS_BRANCH $TRAVIS_COMMIT" \
        --browser-arg browser "$BROWSER" \
        --wsgi-arg port_range.min 65525 \
        --wsgi-arg port_range.max 65535
```