### PR TITLE
Add a way to explicitly override a field's mapping

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,4 +1,18 @@
-0.20 - Patch mpindexer for better error messages
-0.21 - (pypi errors, identical to 0.22)
-0.22 - New version of image magic, fix sauce labs
-0.23 - replace copy.deepcopy() for faster indexing
+0.24:
+- @hitz needs to add entries here for the changes he already merged
+- If the schema specifies an explicit `mapping`,
+  use it when building the elasticsearch mapping.
+  This provides an escape valve for edge cases
+  (such as not indexing the layout structure of a page).
+
+0.23:
+- replace copy.deepcopy() for faster indexing
+
+0.22:
+- New version of image magic, fix sauce labs
+
+0.21:
+- (pypi errors, identical to 0.22)
+
+0.20:
+- Patch mpindexer for better error messages

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,10 @@
 0.24:
-- @hitz needs to add entries here for the changes he already merged
-- If the schema specifies an explicit `mapping`,
-  use it when building the elasticsearch mapping.
-  This provides an escape valve for edge cases
-  (such as not indexing the layout structure of a page).
+
+- If the schema specifies an explicit `mapping`, use it when building the elasticsearch mapping.  This provides an escape valve for edge cases (such as not indexing the layout structure of a page).
+
+- upgrade to sauceconnect v4.4.4 
+
+- add port_range to wsgi_tests (mrmin)
 
 0.23:
 - replace copy.deepcopy() for faster indexing

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 SnoVault JSON-LD Database Framework
 ========================
 
-Version 0.22
+Version 0.24
 
 |Build status|_
 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ tests_require = [
 
 setup(
     name='snovault',
-    version='0.23',
+    version='0.24',
     description='Snovault Hybrid Object Relational Database Framework',
     long_description=README + '\n\n' + CHANGES,
     packages=find_packages('src'),

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -56,13 +56,17 @@ def sorted_dict(d):
 
 
 def schema_mapping(name, schema):
+    # If a mapping is explicitly defined, use it
+    if 'mapping' in schema:
+        return schema['mapping']
+
     if 'linkFrom' in schema:
         type_ = 'string'
     else:
         type_ = schema['type']
 
     # Elasticsearch handles multiple values for a field
-    if type_ == 'array' and schema['items']:
+    if type_ == 'array':
         return schema_mapping(name, schema['items'])
 
     if type_ == 'object':

--- a/src/snowflakes/schemas/page.json
+++ b/src/snowflakes/schemas/page.json
@@ -43,7 +43,13 @@
             "properties": {
                 "rows": {
                     "type": "array",
-                    "items": {}
+                    "items": {
+                        "type": "object",
+                        "mapping": {
+                            "type": "object",
+                            "enabled": false
+                        }
+                    }
                 },
                 "blocks": {
                     "type": "array",


### PR DESCRIPTION
This is needed so I can fix encoded issue 4911 (I need a way to disable indexing of the page type's layout.rows field)

@hitz when you merge this can you add the missing entries to the changelog for the other changes that have been merged to master since 0.23 was released?