### PR TITLE
21 maxtasks

### DIFF
--- a/src/snovault/elasticsearch/mpindexer.py
+++ b/src/snovault/elasticsearch/mpindexer.py
@@ -110,7 +110,7 @@ def update_object_in_snapshot(args):
 # Running in main process
 
 class MPIndexer(Indexer):
-    chunksize = 1
+    chunksize = 32
     maxtasks = 4  # pooled processes will exit and be replaced after this many tasks are completed.
 
     def __init__(self, registry, processes=None):

--- a/src/snovault/elasticsearch/mpindexer.py
+++ b/src/snovault/elasticsearch/mpindexer.py
@@ -110,7 +110,8 @@ def update_object_in_snapshot(args):
 # Running in main process
 
 class MPIndexer(Indexer):
-    chunksize = 32
+    chunksize = 1
+    maxtasks = 4  # pooled processes will exit and be replaced after this many tasks are completed.
 
     def __init__(self, registry, processes=None):
         super(MPIndexer, self).__init__(registry)
@@ -123,6 +124,7 @@ class MPIndexer(Indexer):
             processes=self.processes,
             initializer=initializer,
             initargs=self.initargs,
+            maxtasksperchild=self.maxtasks,
             context=get_context('forkserver'),
         )
 


### PR DESCRIPTION
This just sets maxchildtasks=4 in the multiprocessing Pool used by the indexer.
It has been tested as part of encoded (redmine) ticket 5079: http://redmine.encodedcc.org/issues/5079

