### PR TITLE
Protected the mpindexer chunkiness calc against divide by zero and No…

### DIFF
--- a/src/snovault/elasticsearch/mpindexer.py
+++ b/src/snovault/elasticsearch/mpindexer.py
@@ -131,7 +131,10 @@ class MPIndexer(Indexer):
     def update_objects(self, request, uuids, xmin, snapshot_id):
         # Ensure that we iterate over uuids in this thread not the pool task handler.
         uuid_count = len(uuids)
-        chunkiness = int((uuid_count - 1) / self.processes) + 1
+        workers = 1
+        if self.processes is not None and self.processes > 0:
+            workers = self.processes
+        chunkiness = int((uuid_count - 1) / workers) + 1
         if chunkiness > self.chunksize:
             chunkiness = self.chunksize
 


### PR DESCRIPTION
Tested on local (by editing develop/snovalut) and on unclustered demo with full reindexing (4h29m).