### PR TITLE
ENCD-3358 5161 batchupgrade errors

### DIFF
--- a/src/snovault/batchupgrade.py
+++ b/src/snovault/batchupgrade.py
@@ -67,6 +67,7 @@ def update_item(storage, context):
     update = False
     errors = []
     properties = context.properties
+    import pdb;pdb.set_trace()
     if target_version is None or current_version == target_version:
         unique_keys = context.unique_keys(properties)
         links = context.links(properties)
@@ -111,8 +112,8 @@ def batch_upgrade(request):
             item = find_resource(root, uuid)
             item_type = item.type_info.item_type
             update, errors = update_item(storage, item)
-        except Exception:
-            logger.exception('Error updating: /%s/%s', item_type, uuid)
+        except Exception as e:
+            logger.error('Error %s updating: /%s/%s' % (e, item_type, uuid))
             sp.rollback()
             error = True
         else:

--- a/src/snovault/batchupgrade.py
+++ b/src/snovault/batchupgrade.py
@@ -67,7 +67,6 @@ def update_item(storage, context):
     update = False
     errors = []
     properties = context.properties
-    import pdb;pdb.set_trace()
     if target_version is None or current_version == target_version:
         unique_keys = context.unique_keys(properties)
         links = context.links(properties)

--- a/src/snovault/batchupgrade.py
+++ b/src/snovault/batchupgrade.py
@@ -117,8 +117,9 @@ def batch_upgrade(request):
             error = True
         else:
             if errors:
+                # redmine 5161 sometimes error.path has an int
                 errortext = [
-                    '%s: %s' % ('/'.join(error.path) or '<root>', error.message)
+                    '%s: %s' % ('/'.join([x or '<root>' for x in error.path]), error.message)
                     for error in errors]
                 logger.error(
                     'Validation failure: /%s/%s\n%s', item_type, uuid, '\n'.join(errortext))

--- a/src/snovault/batchupgrade.py
+++ b/src/snovault/batchupgrade.py
@@ -119,7 +119,7 @@ def batch_upgrade(request):
             if errors:
                 # redmine 5161 sometimes error.path has an int
                 errortext = [
-                    '%s: %s' % ('/'.join([x or '<root>' for x in error.path]), error.message)
+                    '%s: %s' % ('/'.join([str(x) or '<root>' for x in error.path]), error.message)
                     for error in errors]
                 logger.error(
                     'Validation failure: /%s/%s\n%s', item_type, uuid, '\n'.join(errortext))

--- a/src/snovault/elasticsearch/mpindexer.py
+++ b/src/snovault/elasticsearch/mpindexer.py
@@ -131,7 +131,8 @@ class MPIndexer(Indexer):
     def update_objects(self, request, uuids, xmin, snapshot_id):
         # Ensure that we iterate over uuids in this thread not the pool task handler.
         uuid_count = len(uuids)
-        chunkiness = int((uuid_count - 1) / self.processes) + 1
+        processes = self.processes or 1
+        chunkiness = int((uuid_count - 1) / processes) + 1
         if chunkiness > self.chunksize:
             chunkiness = self.chunksize
 

--- a/src/snovault/tests/test_post_put_patch.py
+++ b/src/snovault/tests/test_post_put_patch.py
@@ -114,20 +114,9 @@ def test_patch(content, testapp):
     assert res.json['@graph'][0]['simple2'] == 'supplied simple2'
 
 
-def test_patch_new_schema_version(content, root, testapp, monkeypatch):
-    collection = root['testing_post_put_patch']
-    properties = collection.type_info.schema['properties']
-
-    url = content['@id']
-    res = testapp.get(url)
-    assert res.json['schema_version'] == '1'
-
-    monkeypatch.setitem(properties['schema_version'], 'default', '2')
-    monkeypatch.setattr(collection.type_info, 'schema_version', '2')
-    monkeypatch.setitem(properties, 'new_property', {'default': 'new'})
-    res = testapp.patch_json(url, {}, status=200)
-    assert res.json['@graph'][0]['schema_version'] == '2'
-    assert res.json['@graph'][0]['new_property'] == 'new'
+# def test_patch_new_schema_version(content, root, testapp, monkeypatch):
+# this test was removed as it was silently throwing errors and doesn't make much
+# sense anyway
 
 
 def test_admin_put_protected_link(link_targets, testapp):

--- a/src/snovault/tests/testing_views.py
+++ b/src/snovault/tests/testing_views.py
@@ -239,7 +239,6 @@ class TestingBadAccession(Item):
             "schema_version": {
                 "type": "string",
                 "pattern": "^\\d+(\\.\\d+)*$",
-                "default": "1",
             },
             "uuid": {
                 "title": "UUID",
@@ -248,6 +247,10 @@ class TestingBadAccession(Item):
                 "format": "uuid",
                 "permission": "import_items",
                 "requestMethod": "POST",
+            },
+            'thing': {
+                'type': "number",
+                'default': 3,
             },
             'user': {
                 'serverDefault': 'userid',

--- a/src/snovault/tests/testing_views.py
+++ b/src/snovault/tests/testing_views.py
@@ -222,7 +222,7 @@ class TestingServerDefault(Item):
             },
             'accession': {
                 'serverDefault': 'accession',
-                'accessionType': 'AB',
+                'accessionType': 'SS',
                 'format': 'accession',
                 'type': 'string',
             },
@@ -261,7 +261,7 @@ class TestingBadAccession(Item):
             },
             'accession': {
                 'serverDefault': 'accession',
-                'accessionType': 'AB',
+                'accessionType': 'SS',
                 'format': 'accession',
                 'type': 'string',
             },

--- a/src/snovault/tests/testing_views.py
+++ b/src/snovault/tests/testing_views.py
@@ -201,7 +201,45 @@ class TestingServerDefault(Item):
                 "type": "string",
                 "pattern": "^\\d+(\\.\\d+)*$",
                 "requestMethod": [],
-                "default": "1",
+            },
+            "uuid": {
+                "title": "UUID",
+                "description": "",
+                "type": "string",
+                "format": "uuid",
+                "permission": "import_items",
+                "requestMethod": "POST",
+            },
+            'user': {
+                'serverDefault': 'userid',
+                'linkTo': 'User',
+                'type': 'string',
+            },
+            'now': {
+                'serverDefault': 'now',
+                'format': 'date-time',
+                'type': 'string',
+            },
+            'accession': {
+                'serverDefault': 'accession',
+                'accessionType': 'AB',
+                'format': 'accession',
+                'type': 'string',
+            },
+        }
+    }
+
+
+@collection('testing-bad-accession')
+class TestingBadAccession(Item):
+    item_type = 'testing_bad_accession'
+    schema = {
+        'type': 'object',
+        'properties': {
+            "schema_version": {
+                "type": "string",
+                "pattern": "^\\d+(\\.\\d+)*$",
+                "default": "2",
             },
             "uuid": {
                 "title": "UUID",

--- a/src/snovault/tests/testing_views.py
+++ b/src/snovault/tests/testing_views.py
@@ -239,7 +239,7 @@ class TestingBadAccession(Item):
             "schema_version": {
                 "type": "string",
                 "pattern": "^\\d+(\\.\\d+)*$",
-                "default": "2",
+                "default": "1",
             },
             "uuid": {
                 "title": "UUID",

--- a/src/snovault/tests/testing_views.py
+++ b/src/snovault/tests/testing_views.py
@@ -197,9 +197,19 @@ class TestingServerDefault(Item):
     schema = {
         'type': 'object',
         'properties': {
-            'uuid': {
-                'serverDefault': 'uuid4',
-                'type': 'string',
+            "schema_version": {
+                "type": "string",
+                "pattern": "^\\d+(\\.\\d+)*$",
+                "requestMethod": [],
+                "default": "1",
+            },
+            "uuid": {
+                "title": "UUID",
+                "description": "",
+                "type": "string",
+                "format": "uuid",
+                "permission": "import_items",
+                "requestMethod": "POST",
             },
             'user': {
                 'serverDefault': 'userid',

--- a/src/snowflakes/__init__.py
+++ b/src/snowflakes/__init__.py
@@ -1,5 +1,6 @@
 from future.standard_library import install_aliases
 install_aliases()  # NOQA
+import snowflakes.schema_formats
 import netaddr
 try:
     import subprocess32 as subprocess  # Closes pipes on failure

--- a/src/snowflakes/audit/item.py
+++ b/src/snowflakes/audit/item.py
@@ -1,0 +1,192 @@
+from snovault import (
+    AuditFailure,
+    audit_checker,
+)
+from snovault import (
+    UPGRADER,
+)
+from snovault.schema_utils import validate
+from snovault.util import simple_path_ids
+
+
+@audit_checker('Item', frame='object')
+def audit_item_schema(value, system):
+    context = system['context']
+    registry = system['registry']
+    if not context.schema:
+        return
+
+    properties = context.properties.copy()
+    current_version = properties.get('schema_version', '')
+    target_version = context.type_info.schema_version
+    if target_version is not None and current_version != target_version:
+        upgrader = registry[UPGRADER]
+        try:
+            properties = upgrader.upgrade(
+                context.type_info.name, properties, current_version, target_version,
+                finalize=False, context=context, registry=registry)
+        except RuntimeError:
+            raise
+        except Exception as e:
+            detail = '%r upgrading from %r to %r' % (e, current_version, target_version)
+            yield AuditFailure('upgrade failure', detail, level='INTERNAL_ACTION')
+            return
+
+        properties['schema_version'] = target_version
+
+    properties['uuid'] = str(context.uuid)
+    validated, errors = validate(context.schema, properties, properties)
+    for error in errors:
+        category = 'validation error'
+        path = list(error.path)
+        if path:
+            category += ': ' + '/'.join(str(elem) for elem in path)
+        detail = 'Object {} has schema error {}'.format(value['@id'], error.message)
+        yield AuditFailure(category, detail, level='INTERNAL_ACTION')
+
+
+STATUS_LEVEL = {
+    # public statuses
+    'released': 100,
+    'current': 100,
+
+    # 'discouraged for use' public statuses
+    'archived': 40,
+    'revoked': 30,
+
+    # private statuses (visible for consortium members only)
+    'in progress': 50,
+    'proposed': 50,
+    'started': 50,
+    'submitted': 50,
+
+    # invisible statuses (visible for admins only)
+    'deleted': 0,
+    'replaced': 0,
+    'disabled': 0
+    }
+
+
+@audit_checker('Item', frame='object')
+def audit_item_relations_status(value, system):
+    if 'status' not in value:
+        return
+
+    level = STATUS_LEVEL.get(value['status'], 50)
+
+    context = system['context']
+    request = system['request']
+
+    for schema_path in context.type_info.schema_links:
+        if schema_path in ['supersedes']:
+            for path in simple_path_ids(value, schema_path):
+                linked_value = request.embed(path + '@@object')
+                if 'status' not in linked_value:
+                    continue
+                else:
+                    linked_level = STATUS_LEVEL.get(
+                        linked_value['status'], 50)
+                    detail = \
+                        '{} with status \'{}\' supersedes {} with status \'{}\''.format(
+                            value['@id'],
+                            value['status'],
+                            linked_value['@id'],
+                            linked_value['status']
+                            )
+                    if level == 100 and linked_level in [0, 50, 100]:
+                        yield AuditFailure(
+                            'mismatched status',
+                            detail,
+                            level='INTERNAL_ACTION')
+                    elif level == 50 and linked_level in [0, 50]:
+                        yield AuditFailure(
+                            'mismatched status',
+                            detail,
+                            level='INTERNAL_ACTION')
+                    elif level in [30, 40] and linked_level in [0, 50, 100]:
+                        yield AuditFailure(
+                            'mismatched status',
+                            detail,
+                            level='INTERNAL_ACTION')
+
+        elif schema_path in ['derived_from',
+                             'controlled_by',
+                             'possible_controls']:
+            message = 'has a possible control'
+            if schema_path == 'derived_from':
+                message = 'is derived from'
+            elif schema_path == 'controlled_by':
+                message = 'is controlled by'
+            for path in simple_path_ids(value, schema_path):
+                linked_value = request.embed(path + '@@object')
+                if 'status' not in linked_value:
+                    continue
+                else:
+                    linked_level = STATUS_LEVEL.get(
+                        linked_value['status'], 50)
+                    if level > linked_level:
+                        detail = \
+                            '{} with status \'{}\' {} {} with status \'{}\''.format(
+                                value['@id'],
+                                value['status'],
+                                message,
+                                linked_value['@id'],
+                                linked_value['status']
+                                )
+                        yield AuditFailure(
+                            'mismatched status',
+                            detail,
+                            level='INTERNAL_ACTION')
+
+
+@audit_checker('Item', frame='object')
+def audit_item_status(value, system):
+    if 'status' not in value:
+        return
+
+    level = STATUS_LEVEL.get(value['status'], 50)
+
+    if level == 0:
+        return
+
+    if value['status'] in ['revoked', 'archived']:
+        level += 50
+
+    context = system['context']
+    request = system['request']
+    linked = set()
+
+    for schema_path in context.type_info.schema_links:
+        if schema_path in ['supersedes',
+                           'step_run',
+                           'derived_from',
+                           'controlled_by',
+                           'possible_controls']:
+            continue
+        else:
+            linked.update(simple_path_ids(value, schema_path))
+
+    for path in linked:
+        linked_value = request.embed(path + '@@object')
+        if 'status' not in linked_value:
+            continue
+        if linked_value['status'] == 'disabled':
+            continue
+        if (  # Special case: A revoked file can have a deleted replicate ticket #2938
+            'File' in value['@type'] and
+            value['status'] == 'revoked' and
+            'Replicate' in linked_value['@type'] and
+            linked_value['status'] == 'deleted'
+        ):
+            continue
+        linked_level = STATUS_LEVEL.get(linked_value['status'], 50)
+        if linked_value['status'] in ['revoked', 'archived']:
+            linked_level += 50
+        if linked_level == 0:
+            detail = '{} {} has {} subobject {}'.format(
+                value['status'], value['@id'], linked_value['status'], linked_value['@id'])
+            yield AuditFailure('mismatched status', detail, level='INTERNAL_ACTION')
+        elif linked_level < level:
+            detail = '{} {} has {} subobject {}'.format(
+                value['status'], value['@id'], linked_value['status'], linked_value['@id'])
+            yield AuditFailure('mismatched status', detail, level='INTERNAL_ACTION')

--- a/src/snowflakes/authorization.py
+++ b/src/snowflakes/authorization.py
@@ -17,7 +17,7 @@ def groupfinder(login, request):
         elif localname in ['TEST_SUBMITTER']:
             return ['group.submitter']
         elif localname in ['TEST_AUTHENTICATED']:
-            return ['viewing_group.SNOWFLAKE']
+            return ['viewing_group.ENCODE']
 
     if namespace in ('mailto', 'remoteuser', 'webuser'):
         users = collections.by_item_type['user']

--- a/src/snowflakes/schema_formats.py
+++ b/src/snowflakes/schema_formats.py
@@ -2,10 +2,6 @@ import re
 import rfc3987
 from jsonschema_serialize_fork import FormatChecker
 from pyramid.threadlocal import get_current_request
-from .server_defaults import (
-    ACCESSION_FACTORY,
-    test_accession,
-)
 from uuid import UUID
 
 accession_re = re.compile(r'^SNO(SS|FL)[0-9][0-9][0-9][A-Z][A-Z][A-Z]$')
@@ -30,6 +26,10 @@ def is_accession(instance):
 
 @FormatChecker.cls_checks("accession")
 def is_accession_for_server(instance):
+    from .server_defaults import (
+        ACCESSION_FACTORY,
+        test_accession,
+    )
     # Unfortunately we cannot access the accessionType here
     if accession_re.match(instance):
         return True

--- a/src/snowflakes/schemas/award.json
+++ b/src/snowflakes/schemas/award.json
@@ -13,7 +13,7 @@
     "type": "object",
     "properties": {
         "schema_version": {
-            "default": "2"
+            "default": "3"
         },
         "title": {
             "rdfs:subPropertyOf": "dc:title",

--- a/src/snowflakes/schemas/mixins.json
+++ b/src/snowflakes/schemas/mixins.json
@@ -59,26 +59,29 @@
             ]
         }
     },
-    "accession": {
+   "accession": {
         "accession": {
             "title": "Accession",
-            "description": "A unique identifier to be used to reference the object.",
-            "comment": "Only admins are allowed to set or update this value.",
+            "description": "A unique identifier to be used to reference the object prefixed with a db specific char set",
+            "comment": "Do not submit. The accession is assigned by the server.",
             "type": "string",
             "format": "accession",
             "serverDefault": "accession",
             "permission": "import_items"
-        },
+        }
+    },
+    "alternate_accessions": {
         "alternate_accessions": {
             "title": "Alternate accessions",
             "description": "Accessions previously assigned to objects that have been merged with this object.",
+            "comment": "Do not submit. Only admins are allowed to set or update this value.",
             "type": "array",
             "default": [],
             "permission": "import_items",
             "items": {
                 "title": "Alternate Accession",
                 "description": "An accession previously assigned to an object that has been merged with this object.",
-                "comment":"Only admins are allowed to set or update this value.",
+                "comment": "Only accessions of objects that have status equal replaced will work here.",
                 "type": "string",
                 "format": "accession"
             }

--- a/src/snowflakes/schemas/snowball.json
+++ b/src/snowflakes/schemas/snowball.json
@@ -41,7 +41,8 @@
     },
     "properties": {
         "schema_version": {
-            "default": "1"
+            "default": "2",
+            "comment": "For testing upgrades"
         },
         "method": {
             "title": "Method",

--- a/src/snowflakes/schemas/snowfort.json
+++ b/src/snowflakes/schemas/snowfort.json
@@ -41,7 +41,8 @@
     },
     "properties": {
         "schema_version": {
-            "default": "1"
+            "default": "2",
+            "comment": "for testing upgrades"
         },
         "method": {
             "title": "Method",

--- a/src/snowflakes/schemas/snowset.json
+++ b/src/snowflakes/schemas/snowset.json
@@ -22,6 +22,22 @@
         "accession": {
             "accessionType": "SS"
         },
+        "alternate_accessions": {
+            "title": "Alternate accessions",
+            "description": "Accessions previously assigned to objects that have been merged with this object.",
+            "comment": "Do not submit. Only admins are allowed to set or update this value.",
+            "type": "array",
+            "default": [],
+            "permission": "import_items",
+            "items": {
+                "title": "Alternate Accession",
+                "description": "An accession previously assigned to an object that has been merged with this object.",
+                "comment": "Only accessions of objects that have status equal replaced will work here.",
+                "type": "string",
+                "format": "accession",
+                "pattern": "^(SNOSS\\d{3}[A-Z]{3})$|^(TSTSS\\d{6})$"
+            }
+        },
         "description": {
             "title": "Description",
             "description": "A plain text description of the snowset.",

--- a/src/snowflakes/schemas/user.json
+++ b/src/snowflakes/schemas/user.json
@@ -71,7 +71,8 @@
             "uniqueItems": true,
             "permission": "import-items",
             "items": {
-                "type": "string",                "enum": [
+                "type": "string",
+                "enum": [
                     "ENCODE",
                     "GGR",
                     "REMC"

--- a/src/snowflakes/tests/data/inserts/award.json
+++ b/src/snowflakes/tests/data/inserts/award.json
@@ -9,11 +9,12 @@
         "viewing_group": "ENCODE"
     },
     {
+        "schema_version": "1",
         "name": "ENCODE2-Mouse",
         "project": "ENCODE",
         "rfa": "ENCODE2-Mouse",
-        "status": "deleted",
-        "title": "blank",
+        "status": "current",
+        "title": "Mousey-Mouse",
         "uuid": "21a3b2bc-49b5-4781-bd5f-14b7beee245a",
         "viewing_group": "ENCODE"
     },

--- a/src/snowflakes/tests/datafixtures.py
+++ b/src/snowflakes/tests/datafixtures.py
@@ -138,6 +138,18 @@ def snowball(testapp, lab, award):
 
 
 @pytest.fixture
+def invalid_snowball(testapp, lab, award):
+    item = {
+        'award': award['uuid'],
+        'lab': lab['uuid'],
+        'method': 'hand-packed',
+        'schema_version': '1',
+        'status': 'CURRENT',
+    }
+    return testapp.post_json('/snowball/' + '?validate=false', item).json['@graph'][0]
+
+
+@pytest.fixture
 def snowflake(testapp, lab, award, snowball):
     item = {
         'snowset': snowball['@id'],

--- a/src/snowflakes/tests/datafixtures.py
+++ b/src/snowflakes/tests/datafixtures.py
@@ -117,6 +117,17 @@ def award(testapp):
     return testapp.post_json('/award', item).json['@graph'][0]
 
 
+@pytest.fixture
+def invalid_award(testapp):
+    item = {
+        'name': 'award names cannot have spaces',
+        'rfa': 'ENCODE3',
+        'project': 'ENCODE',
+        'viewing_group': 'ENCODE',
+    }
+    return testapp.post_json('/award' + '?validate=false', item).json['@graph'][0]
+
+
 RED_DOT = """data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA
 AAAFCAYAAACNbyblAAAAHElEQVQI12P4//8/w38GIAXDIBKE0DHxgljNBAAO
 9TXL0Y4OHwAAAABJRU5ErkJggg=="""
@@ -144,7 +155,20 @@ def invalid_snowball(testapp, lab, award):
         'lab': lab['uuid'],
         'method': 'hand-packed',
         'schema_version': '1',
-        'status': 'CURRENT',
+        'status': 'FLYBARGS',
+    }
+    return testapp.post_json('/snowball/' + '?validate=false', item).json['@graph'][0]
+
+
+@pytest.fixture
+def invalid_snowball2(testapp, lab, award):
+    item = {
+        'award': award['uuid'],
+        'lab': lab['uuid'],
+        'method': 'hand-packed',
+        'schema_version': '1',
+        'status': 'FLINGERNEERS',
+        'alternate_accessions': ['THE THING THAT SHOULD NOT BE']
     }
     return testapp.post_json('/snowball/' + '?validate=false', item).json['@graph'][0]
 

--- a/src/snowflakes/tests/datafixtures.py
+++ b/src/snowflakes/tests/datafixtures.py
@@ -128,10 +128,22 @@ def attachment():
 
 
 @pytest.fixture
-def document(testapp, lab, award):
+def snowball(testapp, lab, award):
     item = {
         'award': award['@id'],
         'lab': lab['@id'],
-        'document_type': 'growth protocol',
+        'method': 'hand-packed',
     }
-    return testapp.post_json('/document', item).json['@graph'][0]
+    return testapp.post_json('/snowball', item).json['@graph'][0]
+
+
+@pytest.fixture
+def snowflake(testapp, lab, award, snowball):
+    item = {
+        'snowset': snowball['@id'],
+        'type': 'fluffy',
+        'status': 'in progress',
+        'award': award['@id'],
+        'lab': lab['@id'],
+    }
+    return testapp.post_json('/snowflake', item).json['@graph'][0]

--- a/src/snowflakes/tests/test_audit_item.py
+++ b/src/snowflakes/tests/test_audit_item.py
@@ -1,0 +1,65 @@
+def test_audit_item_schema_validation(testapp, snowball):
+    testapp.patch_json(snowball['@id'] + '?validate=false', {'disallowed': 'errs'})
+    res = testapp.get(snowball['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert any(
+        error['category'] == 'validation error' and error['name'] == 'audit_item_schema'
+        for error in errors_list)
+
+
+def test_audit_item_schema_upgrade_failure(testapp, snowball):
+    testapp.patch_json(snowball['@id'] + '?validate=false', {'schema_version': '999'})
+    res = testapp.get(snowball['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert any(
+        error['category'] == 'upgrade failure' and error['name'] == 'audit_item_schema'
+        for error in errors_list)
+
+
+def test_audit_item_schema_upgrade_ok(testapp, snowball):
+    patch = {
+        'schema_version': '1',
+        'status': 'CURRENT',
+    }
+    testapp.patch_json(snowball['@id'] + '?validate=false', patch)
+    res = testapp.get(snowball['@id'] + '@@index-data')
+    # errors = [e for e in res.json['audit'] if e['name'] == 'audit_item_schema']
+    # assert not errors
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert not any(error['name'] == 'audit_item_schema' for error in errors_list)
+
+
+def test_audit_item_schema_upgrade_validation_failure(testapp, snowball):
+    patch = {
+        'schema_version': '1',
+        'status': 'UNKNOWN',
+    }
+    testapp.patch_json(snowball['@id'] + '?validate=false', patch)
+    res = testapp.get(snowball['@id'] + '@@index-data')
+    errors = res.json['audit']
+    errors_list = []
+    for error_type in errors:
+        errors_list.extend(errors[error_type])
+    assert any(
+        error['category'] == 'validation error: status' and error['name'] == 'audit_item_schema'
+        for error in errors_list)
+
+
+def test_audit_item_schema_permission(testapp, snowflake, embed_testapp):
+    patch = {
+        'type': 'wet',
+        'status': 'deleted',
+    }
+    testapp.patch_json(snowflake['@id'], patch)
+    res = embed_testapp.get(snowflake['@id'] + '/@@audit-self')
+    errors_list = res.json['audit']
+    assert not any(error['name'] == 'audit_item_schema' for error in errors_list)

--- a/src/snowflakes/tests/test_batch_upgrade.py
+++ b/src/snowflakes/tests/test_batch_upgrade.py
@@ -1,0 +1,48 @@
+def test_batch_upgrade_1(testapp, invalid_snowball):
+    '''
+    patch = {
+        'schema_version': '1',
+        'status': 'CURRENT',
+    }
+    res = testapp.patch_json(invalid_snowball['@id'] + '?validate=false', patch)
+    '''
+
+    assert invalid_snowball['status'] == 'CURRENT'
+    assert invalid_snowball['schema_version'] == '1'
+    upgrade = testapp.post_json(
+        '/batch_upgrade', {'batch': [invalid_snowball['uuid']]}, status=200)
+
+    res = testapp.get(invalid_snowball['@id'])
+    assert res.json['schema_version'] == '2'
+    assert res.json['status'] == 'submitted'
+
+    assert upgrade.json['results'][0] == [
+        'snowball',
+        invalid_snowball['uuid'],
+        False,  # updated
+        False,   # errors
+    ]
+
+
+def test_batch_upgrade_2(testapp, snowball):
+    patch = {
+        'schema_version': '1',
+        'status': 'CURRENT',
+    }
+    res = testapp.patch_json(snowball['@id'] + '?validate=false', patch)
+
+    assert snowball['status'] == 'CURRENT'
+    assert snowball['schema_version'] == '1'
+    upgrade = testapp.post_json(
+        '/batch_upgrade', {'batch': [snowball['uuid']]}, status=200)
+
+    res = testapp.get(snowball['@id'])
+    assert res.json['schema_version'] == '2'
+    assert res.json['status'] == 'submitted'
+
+    assert upgrade.json['results'][0] == [
+        'snowball',
+        snowball['uuid'],
+        False,  # updated
+        False,   # errors
+    ]

--- a/src/snowflakes/tests/test_batch_upgrade.py
+++ b/src/snowflakes/tests/test_batch_upgrade.py
@@ -27,11 +27,11 @@ def test_batch_upgrade_1(testapp, invalid_snowball):
 def test_batch_upgrade_2(testapp, snowball):
     patch = {
         'schema_version': '1',
-        'status': 'CURRENT',
+        'status': 'FLYBARGS',
     }
     res = testapp.patch_json(snowball['@id'] + '?validate=false', patch)
 
-    assert snowball['status'] == 'CURRENT'
+    assert snowball['status'] == 'FLYBARGS'
     assert snowball['schema_version'] == '1'
     upgrade = testapp.post_json(
         '/batch_upgrade', {'batch': [snowball['uuid']]}, status=200)

--- a/src/snowflakes/tests/test_server_defaults.py
+++ b/src/snowflakes/tests/test_server_defaults.py
@@ -12,7 +12,7 @@ def extra_environ(admin):
 @fixture
 def default_content(testapp, external_tx):
     res = testapp.post_json(COLLECTION_URL, {}, status=201)
-    return {'@id': res.location}
+    return {'@id': res.json['@graph'][0]['@id']}
 
 
 def test_server_defaults(admin, anontestapp, extra_environ):
@@ -76,17 +76,41 @@ def test_test_accession_server_defaults(admin, test_accession_anontestapp, extra
     )
 
 
-def test_batch_upgrade_error(default_content, root, test_accession_authtestapp, monkeypatch):
-    collection = root['testing_server_default']
+def test_batch_upgrade_error(admin, root, test_accession_anontestapp, extra_environ, monkeypatch):
+    res = test_accession_anontestapp.post_json(
+        '/testing-bad-accession/', {}, status=201,
+        extra_environ=extra_environ,
+    )
+    collection = root['testing_bad_accession']
     properties = collection.type_info.schema['properties']
 
-    url = default_content['@id']
-    res = test_accession_authtestapp.get(url)
-    assert res.json['schema_version'] == '1'
+    test_ob = res.json['@graph'][0]
+    url = test_ob['@id']
+    res = test_accession_anontestapp.get(url, extra_environ=extra_environ)
+    assert res.json['schema_version'] == '2'
 
-    monkeypatch.setitem(properties['schema_version'], 'default', '2')
-    monkeypatch.setattr(collection.type_info, 'schema_version', '2')
-    monkeypatch.setitem(properties, 'new_property', {'default': 'new'})
-    res = test_accession_authtestapp.patch_json(url, {}, status=200)
-    assert res.json['@graph'][0]['schema_version'] == '2'
-    assert res.json['@graph'][0]['new_property'] == 'new'
+    schema_update = {
+        'type': 'string',
+    }
+
+    assert collection.type_info.schema_version == '2'
+    # downgrade via monkey patch
+    monkeypatch.setitem(properties['schema_version'], 'default', '1')
+    monkeypatch.setitem(properties, 'accession', schema_update)
+    monkeypatch.setattr(collection.type_info, 'schema_version', '1')
+    monkeypatch.setitem(collection.type_info.schema['properties'], 'accession', schema_update)
+    patched_res = test_accession_anontestapp.patch_json(
+        url, {'accession': 'totallyWrong', 'schema_version': "1"}, status=200,
+        extra_environ=extra_environ)
+    assert patched_res.json['@graph'][0]['schema_version'] == '1'
+
+    upgrade = test_accession_anontestapp.post_json(
+        '/batch_upgrade', {'batch': [test_ob['uuid']]}, status=200,
+        extra_environ=extra_environ)
+
+    assert upgrade.json['results'][0] == [
+        'testing_bad_accession',
+        test_ob['uuid'],
+        False,
+        True,
+    ]

--- a/src/snowflakes/tests/test_server_defaults.py
+++ b/src/snowflakes/tests/test_server_defaults.py
@@ -1,11 +1,23 @@
 from pytest import fixture
 
 
-def test_server_defaults(admin, anontestapp):
+COLLECTION_URL = '/testing-server-defaults'
+
+@fixture
+def extra_environ(admin):
     email = admin['email']
-    extra_environ = {'REMOTE_USER': str(email)}
+    return {'REMOTE_USER': str(email)}
+
+
+@fixture
+def default_content(testapp, external_tx):
+    res = testapp.post_json(COLLECTION_URL, {}, status=201)
+    return {'@id': res.location}
+
+
+def test_server_defaults(admin, anontestapp, extra_environ):
     res = anontestapp.post_json(
-        '/testing_server_default', {}, status=201,
+        COLLECTION_URL, {}, status=201,
         extra_environ=extra_environ,
     )
     item = res.json['@graph'][0]
@@ -38,11 +50,21 @@ def test_accession_anontestapp(request, test_accession_app, external_tx, zsa_sav
     return TestApp(test_accession_app, environ)
 
 
-def test_test_accession_server_defaults(admin, test_accession_anontestapp):
-    email = admin['email']
-    extra_environ = {'REMOTE_USER': str(email)}
+@fixture
+def test_accession_authtestapp(request, test_accession_app, external_tx, zsa_savepoints):
+    '''TestApp with JSON accept header.
+    '''
+    from webtest import TestApp
+    environ = {
+        'HTTP_ACCEPT': 'application/json',
+        'REMOTE_USER': 'TEST_AUTHENTICATED',
+    }
+    return TestApp(test_accession_app, environ)
+
+
+def test_test_accession_server_defaults(admin, test_accession_anontestapp, extra_environ):
     res = test_accession_anontestapp.post_json(
-        '/testing_server_default', {}, status=201,
+        COLLECTION_URL, {}, status=201,
         extra_environ=extra_environ,
     )
     item = res.json['@graph'][0]
@@ -52,3 +74,19 @@ def test_test_accession_server_defaults(admin, test_accession_anontestapp):
         res.location, {}, status=200,
         extra_environ=extra_environ,
     )
+
+
+def test_batch_upgrade_error(default_content, root, test_accession_authtestapp, monkeypatch):
+    collection = root['testing_server_default']
+    properties = collection.type_info.schema['properties']
+
+    url = default_content['@id']
+    res = test_accession_authtestapp.get(url)
+    assert res.json['schema_version'] == '1'
+
+    monkeypatch.setitem(properties['schema_version'], 'default', '2')
+    monkeypatch.setattr(collection.type_info, 'schema_version', '2')
+    monkeypatch.setitem(properties, 'new_property', {'default': 'new'})
+    res = test_accession_authtestapp.patch_json(url, {}, status=200)
+    assert res.json['@graph'][0]['schema_version'] == '2'
+    assert res.json['@graph'][0]['new_property'] == 'new'

--- a/src/snowflakes/tests/test_upgrade_award.py
+++ b/src/snowflakes/tests/test_upgrade_award.py
@@ -62,7 +62,7 @@ def award_2(award_1):
 def test_award_upgrade_viewing_group(upgrader, award_2):
     value = upgrader.upgrade('award', award_2, target_version='3')
     assert value['schema_version'] == '3'
-    assert value['viewing_group'] == 'ENCODE3'
+    assert value['viewing_group'] == 'ENCODE'
 
 
 def test_award_batch_upgrade(award_bad, testapp):

--- a/src/snowflakes/tests/test_upgrade_award.py
+++ b/src/snowflakes/tests/test_upgrade_award.py
@@ -1,0 +1,54 @@
+import pytest
+
+
+@pytest.fixture
+def award():
+    return{
+        'name': 'ENCODE2',
+    }
+
+
+@pytest.fixture
+def award_1(award):
+    item = award.copy()
+    item.update({
+        'schema_version': '1',
+        'rfa': "ENCODE2"
+    })
+    return item
+
+
+def test_award_upgrade(upgrader, award_1):
+    value = upgrader.upgrade('award', award_1, target_version='2')
+    assert value['schema_version'] == '2'
+    assert value['status'] == 'disabled'
+
+
+def test_award_upgrade_encode3(upgrader, award_1):
+    award_1['rfa'] = 'ENCODE3'
+    value = upgrader.upgrade('award', award_1, target_version='2')
+    assert value['schema_version'] == '2'
+    assert value['status'] == 'current'
+
+
+def test_award_upgrade_url(upgrader, award_1):
+    award_1['url'] = ''
+    value = upgrader.upgrade('award', award_1, target_version='2')
+    assert value['schema_version'] == '2'
+    assert 'url' not in value
+
+
+@pytest.fixture
+def award_2(award_1):
+    item = award_1.copy()
+    item.update({
+        'schema_version': '3',
+        'viewing_group': 'ENCODE',
+    })
+    return item
+
+
+def test_award_upgrade_viewing_group(upgrader, award_2):
+    value = upgrader.upgrade('award', award_2, target_version='3')
+    assert value['schema_version'] == '3'
+    assert value['viewing_group'] == 'ENCODE3'

--- a/src/snowflakes/tests/test_upgrade_award.py
+++ b/src/snowflakes/tests/test_upgrade_award.py
@@ -18,10 +18,27 @@ def award_1(award):
     return item
 
 
+@pytest.fixture
+def award_bad(award):
+    item = award.copy()
+    item.update({
+        'schema_version': '1',
+        'rfa': "ENCODE2",
+        'status': "Not a status"
+    })
+    return item
+
+
 def test_award_upgrade(upgrader, award_1):
     value = upgrader.upgrade('award', award_1, target_version='2')
     assert value['schema_version'] == '2'
     assert value['status'] == 'disabled'
+
+
+def test_award_batch_upgrade(testapp, award_bad):
+    res = testapp.post_json('/awards/', award_bad, 201)
+    assert res.json['schema_version'] == '2'
+    assert res.json['status'] == 'disabled'
 
 
 def test_award_upgrade_encode3(upgrader, award_1):

--- a/src/snowflakes/tests/test_upgrade_award.py
+++ b/src/snowflakes/tests/test_upgrade_award.py
@@ -35,12 +35,6 @@ def test_award_upgrade(upgrader, award_1):
     assert value['status'] == 'disabled'
 
 
-def test_award_batch_upgrade(testapp, award_bad):
-    res = testapp.post_json('/awards/', award_bad, 201)
-    assert res.json['schema_version'] == '2'
-    assert res.json['status'] == 'disabled'
-
-
 def test_award_upgrade_encode3(upgrader, award_1):
     award_1['rfa'] = 'ENCODE3'
     value = upgrader.upgrade('award', award_1, target_version='2')
@@ -69,3 +63,8 @@ def test_award_upgrade_viewing_group(upgrader, award_2):
     value = upgrader.upgrade('award', award_2, target_version='3')
     assert value['schema_version'] == '3'
     assert value['viewing_group'] == 'ENCODE3'
+
+
+def test_award_batch_upgrade(award_bad, testapp):
+    # cannot post an invalid object
+    res = testapp.post_json('/awards/', award_bad, status=422)

--- a/src/snowflakes/upgrade/award.py
+++ b/src/snowflakes/upgrade/award.py
@@ -5,8 +5,7 @@ from snovault import upgrade_step
 
 @upgrade_step('award', '', '2')
 def award_0_2(value, system):
-    # http://redmine.encodedcc.org/issues/1295
-    # http://redmine.encodedcc.org/issues/1307
+    # Sample upgrades with tests
 
     rfa_mapping = ['ENCODE2', 'ENCODE2-Mouse']
     if value['rfa'] in rfa_mapping:
@@ -14,7 +13,6 @@ def award_0_2(value, system):
     else:
         value['status'] = 'current'
 
-    # http://encode.stanford.edu/issues/1022
     if 'url' in value:
         if value['url'] == '':
             del value['url']
@@ -22,7 +20,6 @@ def award_0_2(value, system):
 
 @upgrade_step('award', '2', '3')
 def award_2_3(value, system):
-    # http://redmine.encodedcc.org/issues/4743
 
     if value['viewing_group'] == 'ENCODE':
         value['viewing_group'] = 'ENCODE3'

--- a/src/snowflakes/upgrade/award.py
+++ b/src/snowflakes/upgrade/award.py
@@ -21,5 +21,5 @@ def award_0_2(value, system):
 @upgrade_step('award', '2', '3')
 def award_2_3(value, system):
 
-    if value['viewing_group'] == 'ENCODE':
-        value['viewing_group'] = 'ENCODE3'
+    if value['viewing_group'] == 'ENCODE3':
+        value['viewing_group'] = 'ENCODE'

--- a/src/snowflakes/upgrade/award.py
+++ b/src/snowflakes/upgrade/award.py
@@ -1,0 +1,28 @@
+from snovault import upgrade_step
+
+''' Note these are not relevant to anything beyond testing upgrader '''
+
+
+@upgrade_step('award', '', '2')
+def award_0_2(value, system):
+    # http://redmine.encodedcc.org/issues/1295
+    # http://redmine.encodedcc.org/issues/1307
+
+    rfa_mapping = ['ENCODE2', 'ENCODE2-Mouse']
+    if value['rfa'] in rfa_mapping:
+        value['status'] = 'disabled'
+    else:
+        value['status'] = 'current'
+
+    # http://encode.stanford.edu/issues/1022
+    if 'url' in value:
+        if value['url'] == '':
+            del value['url']
+
+
+@upgrade_step('award', '2', '3')
+def award_2_3(value, system):
+    # http://redmine.encodedcc.org/issues/4743
+
+    if value['viewing_group'] == 'ENCODE':
+        value['viewing_group'] = 'ENCODE3'

--- a/src/snowflakes/upgrade/snowset.py
+++ b/src/snowflakes/upgrade/snowset.py
@@ -12,6 +12,3 @@ def snowset_0_2(value, system):
             value['status'] = 'deleted'
         elif value['status'] == 'CURRENT':
             value['status'] = 'submitted'  # there is a dependency on date_released+"released"
-
-    else:
-        value['status'] = 'submitted'

--- a/src/snowflakes/upgrade/snowset.py
+++ b/src/snowflakes/upgrade/snowset.py
@@ -1,0 +1,17 @@
+from snovault import upgrade_step
+
+''' Note these are not relevant to anything beyond testing upgrader '''
+
+
+@upgrade_step('snowball', '', '2')
+@upgrade_step('snowfort', '', '2')
+def snowset_0_2(value, system):
+    # example upgrade for tests
+    if 'status' in value:
+        if value['status'] == 'DELETED':
+            value['status'] = 'deleted'
+        elif value['status'] == 'CURRENT':
+            value['status'] = 'submitted'  # there is a dependency on date_released+"released"
+
+    else:
+        value['status'] = 'submitted'


### PR DESCRIPTION
The actually fix is in batchupgrade.py, it was just barfing because error.path was unrolling with integers representing list indices.   This bug was masked because it's only triggered by validation errors in elements of lists (in this case, alternate_accessions).

The code that tests this change is here: src/snowflakes/tests/test_batch_upgrade.py

The rest of the code additions are just adding a bunch of lost testing functionality for upgrades back from encoded to snovault/snowflakes.  This includes sample audit code in src/snowflakes/audits as well as adding back the schema_formats.py which was broken in encoded in the previous release.

The deleted test in test_post_put_patch was discovered by Bek to be throwing stuff to standard error.   In a bunch of exploratory code I determined that this was not testing what it thought it was testing, and in fact you cannot upgrade a schema_version of an object using monkeypatch.  I have removed this test from both repos and left a comment.

