### PR TITLE
ENCD-3583 fix field permissions for nested schemas

### DIFF
--- a/src/snovault/util.py
+++ b/src/snovault/util.py
@@ -83,3 +83,18 @@ def quick_deepcopy(obj):
     elif isinstance(obj, list):
         obj = [quick_deepcopy(v) for v in obj]
     return obj
+
+
+def mutated_schema(schema, mutator):
+    """Apply a change to all levels of a schema.
+
+    Returns a new schema rather than modifying the original.
+    """
+    schema = mutator(schema.copy())
+    if 'items' in schema:
+        schema['items'] = mutated_schema(schema['items'], mutator)
+    if 'properties' in schema:
+        schema['properties'] = schema['properties'].copy()
+        for k, v in schema['properties'].items():
+            schema['properties'][k] = mutated_schema(v, mutator)
+    return schema


### PR DESCRIPTION
The schema views are supposed to set `readonly: True` for a property if it uses a permission that the current user does not have. This fixes that to work at any level of a schema, not just the top level of properties.