### PR TITLE
Stale audit code interfered with 1-pass indexing.

### DIFF
--- a/src/snovault/elasticsearch/indexer.py
+++ b/src/snovault/elasticsearch/indexer.py
@@ -560,15 +560,17 @@ class Indexer(object):
             last_exc = repr(e)
 
         if last_exc is None:
-            try:
-                audit = self.es.get(index=self.index, id=str(uuid)).get('_source',{}).get('audit')  # Any version
-                if audit:
-                    doc.update(
-                        audit=audit,
-                        audit_stale=True,
-                    )
-            except:
-                pass
+            ### OPTIONAL: audit via 2-pass is coming...
+            #try:
+            #    audit = self.es.get(index=self.index, id=str(uuid)).get('_source',{}).get('audit')  # Any version
+            #    if audit:
+            #        doc.update(
+            #            audit=audit,
+            #            audit_stale=True,
+            #        )
+            #except:
+            #    pass
+            ### OPTIONAL: audit via 2-pass is coming...
 
             for backoff in [0, 10, 20, 40, 80]:
                 time.sleep(backoff)


### PR DESCRIPTION
Code commented out (as other 2-pass code is).  This stale audit code was not interfering with original indexing but was interfering when audits were supposed to change.