### PR TITLE
Specify https index to fix buildout, update changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,40 @@
+0.31:
+
+- Fix development build.
+
+0.30:
+
+- Document dependency on java 8.
+
+- Disable 2nd indexing pass.
+
+0.29:
+
+- Fix recording indexing errors.
+
+- Add some documentation about indexing.
+
+0.28:
+
+- Add support for adding and updating child objects
+  specified as abstract types in the schema.
+
+- Split indexing into 2 phases.
+
+0.27:
+
+- Move embed cache to connection and increase size.
+
+- Fix reporting upgrade errors when error path includes an integer.
+
+0.26:
+
+- Indexer: Limit workers to 1 task and scale chunk size based on number of items being indexed.
+
+0.25:
+
+- Indexer: Limit workers to 4 tasks to avoid out-of-memory errors.
+
 0.24:
 
 - If the schema specifies an explicit `mapping`, use it when building the elasticsearch mapping.  This provides an escape valve for edge cases (such as not indexing the layout structure of a page).

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,6 @@
 SnoVault JSON-LD Database Framework
 ========================
 
-Version 0.28
-
 |Build status|_
 
 .. |Build status| image:: https://travis-ci.org/ENCODE-DCC/snovault.png?branch=master

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,6 +6,7 @@ extends = versions.cfg
 allow-hosts =
     *.python.org
     github.com
+index = https://pypi.python.org/simple/
 find-links =
     https://github.com/lrowe/venusian/tarball/1.0.1.dev40#egg=venusian-1.0.1.dev40
     https://github.com/lrowe/splinter/tarball/0.7.3.dev20150610#egg=splinter-0.7.3.dev20150610


### PR DESCRIPTION
Here is a fix for the "Couldn't find a distribution" errors that doesn't require messing with buildout and setuptools versions.