### PR TITLE
ENCD-3669(update) Omit notSubmittable rev links in edit view

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.32:
+
+- Don't include notSubmittable reverse links in the edit view
+  of an object.
+
 0.31:
 
 - ENCD-3684 Specify https index to fix buildout, update

--- a/src/snovault/typeinfo.py
+++ b/src/snovault/typeinfo.py
@@ -107,6 +107,8 @@ class TypeInfo(AbstractTypeInfo):
     def schema_rev_links(self):
         revs = {}
         for key, prop in self.schema['properties'].items():
+            if prop.get('notSubmittable'):
+                continue
             linkFrom = prop.get('linkFrom', prop.get('items', {}).get('linkFrom'))
             if linkFrom is None:
                 continue


### PR DESCRIPTION
Here is a follow-up to my previous change for ENCD-3669, to fix an issue that was discovered during QA (see discussion on the ticket). The edit view of an object should not include properties that cannot be submitted.

Unlike my last snovault change, there is no corresponding change in encoded which depends on this. So this just needs to be merged, released, and then encoded updated to the new release.