### PR TITLE
SNO-19 Update DOI preferred resolver url

### DIFF
--- a/src/snowflakes/static/components/globals.js
+++ b/src/snowflakes/static/components/globals.js
@@ -142,7 +142,7 @@ module.exports.encodeVersion = function(context) {
 module.exports.dbxref_prefix_map = {
     "PMID": "http://www.ncbi.nlm.nih.gov/pubmed/?term=",
     "PMCID": "http://www.ncbi.nlm.nih.gov/pmc/articles/",
-    "doi": "http://dx.doi.org/doi:",
+    "doi": "https://doi.org/doi:",
     // Antibody RRids
     "AR": "http://antibodyregistry.org/search.php?q="
 };


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers :-)