### PR TITLE
SNO-25 Make uniqueItems to check the serialized values

### DIFF
--- a/src/snovault/schema_utils.py
+++ b/src/snovault/schema_utils.py
@@ -250,6 +250,17 @@ def permission(validator, permission, instance, schema):
         yield IgnoreUnchanged(error)
 
 
+orig_uniqueItems = Draft4Validator.VALIDATORS['uniqueItems']
+
+
+def uniqueItems(validator, uI, instance, schema):
+    # Use serialized items if available
+    # (this gives the linkTo validator a chance to normalize paths into uuids)
+    if validator._serialize and validator._validated[-1]:
+        instance = validator._validated[-1]
+    yield from orig_uniqueItems(validator, uI, instance, schema)
+
+
 VALIDATOR_REGISTRY = {}
 
 
@@ -279,6 +290,7 @@ class SchemaValidator(Draft4Validator):
     VALIDATORS['linkFrom'] = linkFrom
     VALIDATORS['permission'] = permission
     VALIDATORS['requestMethod'] = requestMethod
+    VALIDATORS['uniqueItems'] = uniqueItems
     VALIDATORS['validators'] = validators
     SERVER_DEFAULTS = SERVER_DEFAULTS
 

--- a/src/snovault/tests/test_schema_utils.py
+++ b/src/snovault/tests/test_schema_utils.py
@@ -1,0 +1,34 @@
+from snovault.schema_utils import validate
+import pytest
+
+
+targets = [
+    {'name': 'one', 'uuid': '775795d3-4410-4114-836b-8eeecf1d0c2f'},
+]
+
+
+@pytest.fixture
+def content(testapp):
+    url = '/testing-link-targets/'
+    for item in targets:
+        testapp.post_json(url, item, status=201)
+
+
+def test_uniqueItems_validates_normalized_links(content, threadlocals):
+    schema = {
+        'uniqueItems': True,
+        'items': {
+            'linkTo': 'TestingLinkTarget',
+        }
+    }
+    uuid = targets[0]['uuid']
+    data = [
+        uuid,
+        '/testing-link-targets/{}'.format(uuid),
+    ]
+    validated, errors = validate(schema, data)
+    assert len(errors) == 1
+    assert (
+        errors[0].message == "['{}', '{}'] has non-unique elements".format(
+            uuid, uuid)
+    )


### PR DESCRIPTION
This addresses https://encodedcc.atlassian.net/browse/SNO-25 where if the same linked object was specified in two different forms (i.e. uuid and @id), uniqueItems would not catch it.

I'm fixing this by overriding the `uniqueItems` validator to look at the validated, serialized values returned from the `items` subschema (in the case discussed in the ticket, those are normalized to uuids by the `linkTo` validator) rather than the raw values from the request. This will only be in place if the `items` validator is processed before the `uniqueItems` validator; fortunately the `jsonschema` library explicitly sets up `items` to run early.