### PR TITLE
SNO-29 Limit audits on form update

### DIFF
--- a/src/snovault/auditor.py
+++ b/src/snovault/auditor.py
@@ -250,8 +250,10 @@ def item_view_audit(context, request):
 
 
 def audit_condition(context, request):
-    # Don't embed audits unless they are precached in elasticsearch
-    if not ICachedItem.providedBy(context):
+    # Audits must be explicitly requested if they
+    # are not available in precached form from elasticsearch
+    force_audit = request.params.get('audit', False)
+    if not ICachedItem.providedBy(context) and not force_audit:
         return False
     # Don't embed audits unless user has permission to see them
     if not request.has_permission('audit'):

--- a/src/snovault/elasticsearch/esstorage.py
+++ b/src/snovault/elasticsearch/esstorage.py
@@ -80,11 +80,17 @@ class PickStorage(object):
             return self.read
         return self.write
 
+    def force_database(self):
+        request = get_current_request()
+        if request:
+            request.datastore = 'database'
+
     def get_by_uuid(self, uuid):
         storage = self.storage()
         model = storage.get_by_uuid(uuid)
         if storage is self.read:
             if model is None or model.invalidated():
+                self.force_database()
                 return self.write.get_by_uuid(uuid)
         return model
 
@@ -93,6 +99,7 @@ class PickStorage(object):
         model = storage.get_by_unique_key(unique_key, name)
         if storage is self.read:
             if model is None or model.invalidated():
+                self.force_database()
                 return self.write.get_by_unique_key(unique_key, name)
         return model
 


### PR DESCRIPTION
This makes 2 changes to help performance just after an item is edited:
1. If an item is fetched from elasticsearch but turns out to have been invalidated, then set the request's datastore to `database` so that fetches of other items will go directly to the database (basically, assume that they are likely to have been invalidated too).
2. Don't embed audits in items unless they were fetched from elasticsearch. This way we only incur the overhead of calculating audits while indexing.