### PR TITLE
SNO-28 limit ES storage to indices created for snovault resources

### DIFF
--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -450,6 +450,10 @@ def set_index_mapping(es, index, doc_type, mapping):
     es.indices.put_mapping(index=index, doc_type=doc_type, body=mapping, ignore=[400], request_timeout=300)
 
 
+def create_snovault_index_alias(es, indices):
+    es.indices.put_alias(index=','.join(indices), name='snovault-resources', request_timeout=300)
+
+
 def run(app, collections=None, dry_run=False):
     index = app.registry.settings['snovault.elasticsearch.index']
     registry = app.registry
@@ -460,6 +464,7 @@ def run(app, collections=None, dry_run=False):
     if not collections:
         collections = ['meta'] + list(registry[COLLECTIONS].by_item_type.keys())
 
+    indices = []
     for collection_name in collections:
         if collection_name == 'meta':
             doc_type = 'meta'
@@ -476,6 +481,9 @@ def run(app, collections=None, dry_run=False):
             continue
         create_elasticsearch_index(es, index, index_settings())
         set_index_mapping(es, index, doc_type, {doc_type: mapping})
+        indices.append(index)
+
+    create_snovault_index_alias(es, indices)
 
 
 def main():

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -13,7 +13,10 @@ from snovault import (
     TYPES,
 )
 from snovault.schema_utils import combine_schemas
-from .interfaces import ELASTIC_SEARCH
+from .interfaces import (
+    ELASTIC_SEARCH,
+    RESOURCES_INDEX,
+)
 import collections
 import json
 import logging
@@ -451,7 +454,7 @@ def set_index_mapping(es, index, doc_type, mapping):
 
 
 def create_snovault_index_alias(es, indices):
-    es.indices.put_alias(index=','.join(indices), name='snovault-resources', request_timeout=300)
+    es.indices.put_alias(index=','.join(indices), name=RESOURCES_INDEX, request_timeout=300)
 
 
 def run(app, collections=None, dry_run=False):
@@ -481,7 +484,8 @@ def run(app, collections=None, dry_run=False):
             continue
         create_elasticsearch_index(es, index, index_settings())
         set_index_mapping(es, index, doc_type, {doc_type: mapping})
-        indices.append(index)
+        if collection_name != 'meta':
+            indices.append(index)
 
     create_snovault_index_alias(es, indices)
 

--- a/src/snovault/elasticsearch/esstorage.py
+++ b/src/snovault/elasticsearch/esstorage.py
@@ -5,6 +5,7 @@ from zope.interface import alsoProvides
 from .interfaces import (
     ELASTIC_SEARCH,
     ICachedItem,
+    RESOURCES_INDEX,
 )
 
 
@@ -15,7 +16,7 @@ def includeme(config):
     from snovault import STORAGE
     registry = config.registry
     es = registry[ELASTIC_SEARCH]
-    es_index = 'snovault-resources'
+    es_index = RESOURCES_INDEX
     wrapped_storage = registry[STORAGE]
     registry[STORAGE] = PickStorage(ElasticSearchStorage(es, es_index), wrapped_storage)
 

--- a/src/snovault/elasticsearch/esstorage.py
+++ b/src/snovault/elasticsearch/esstorage.py
@@ -15,7 +15,7 @@ def includeme(config):
     from snovault import STORAGE
     registry = config.registry
     es = registry[ELASTIC_SEARCH]
-    es_index = '_all'
+    es_index = 'snovault-resources'
     wrapped_storage = registry[STORAGE]
     registry[STORAGE] = PickStorage(ElasticSearchStorage(es, es_index), wrapped_storage)
 

--- a/src/snovault/elasticsearch/interfaces.py
+++ b/src/snovault/elasticsearch/interfaces.py
@@ -5,6 +5,7 @@ APP_FACTORY = 'app_factory'
 ELASTIC_SEARCH = 'elasticsearch'
 SNP_SEARCH_ES = 'snp_search'
 INDEXER = 'indexer'
+RESOURCES_INDEX = 'snovault-resources'
 
 
 class ICachedItem(Interface):

--- a/src/snowflakes/search.py
+++ b/src/snowflakes/search.py
@@ -4,10 +4,8 @@ from snovault import (
     AbstractCollection,
     TYPES,
 )
-from snovault.elasticsearch import (
-    ELASTIC_SEARCH,
-    RESOURCES_INDEX,
-)
+from snovault.elasticsearch import ELASTIC_SEARCH
+from snovault.elasticsearch.interfaces import RESOURCES_INDEX
 from snovault.resource_views import collection_view_listing_db
 from elasticsearch.helpers import scan
 from pyramid.httpexceptions import HTTPBadRequest

--- a/src/snowflakes/search.py
+++ b/src/snowflakes/search.py
@@ -4,7 +4,10 @@ from snovault import (
     AbstractCollection,
     TYPES,
 )
-from snovault.elasticsearch import ELASTIC_SEARCH
+from snovault.elasticsearch import (
+    ELASTIC_SEARCH,
+    RESOURCES_INDEX,
+)
 from snovault.resource_views import collection_view_listing_db
 from elasticsearch.helpers import scan
 from pyramid.httpexceptions import HTTPBadRequest
@@ -606,7 +609,7 @@ def search(context, request, search_type=None, return_generator=False):
     }
     principals = effective_principals(request)
     es = request.registry[ELASTIC_SEARCH]
-    es_index = 'snovault-resources'
+    es_index = RESOURCES_INDEX
     search_audit = request.has_permission('search_audit')
 
 
@@ -731,10 +734,10 @@ def search(context, request, search_type=None, return_generator=False):
 
     # Send search request to proper indices
     if not request.params.get('type') or 'Item' in doc_types:
-        es_index = 'snovault-resources'
+        es_index = RESOURCES_INDEX
     else:
         es_index = [types[type_name].item_type for type_name in doc_types if hasattr(types[type_name], 'item_type')]
-    
+
     # Execute the query
     if do_scan:
         es_results = es.search(body=query, index=es_index, search_type='query_then_fetch')

--- a/src/snowflakes/search.py
+++ b/src/snowflakes/search.py
@@ -606,7 +606,7 @@ def search(context, request, search_type=None, return_generator=False):
     }
     principals = effective_principals(request)
     es = request.registry[ELASTIC_SEARCH]
-    es_index = '_all'
+    es_index = 'snovault-resources'
     search_audit = request.has_permission('search_audit')
 
 
@@ -731,7 +731,7 @@ def search(context, request, search_type=None, return_generator=False):
 
     # Send search request to proper indices
     if not request.params.get('type') or 'Item' in doc_types:
-        es_index = '_all'
+        es_index = 'snovault-resources'
     else:
         es_index = [types[type_name].item_type for type_name in doc_types if hasattr(types[type_name], 'item_type')]
     


### PR DESCRIPTION
This avoids searching unrelated indexes such as the vis cache and regions. Seems to make getting a single object 40-100% faster on my laptop with test data.