### PR TITLE
SNO-33 Specify index for get_by_unique_key from collection

### DIFF
--- a/src/snovault/connection.py
+++ b/src/snovault/connection.py
@@ -62,14 +62,14 @@ class Connection(object):
         self.item_cache[uuid] = item
         return item
 
-    def get_by_unique_key(self, unique_key, name, default=None):
+    def get_by_unique_key(self, unique_key, name, default=None, index=None):
         pkey = (unique_key, name)
 
         cached = self.unique_key_cache.get(pkey)
         if cached is not None:
             return self.get_by_uuid(cached)
 
-        model = self.storage.get_by_unique_key(unique_key, name)
+        model = self.storage.get_by_unique_key(unique_key, name, index=index)
         if model is None:
             return default
 

--- a/src/snovault/resources.py
+++ b/src/snovault/resources.py
@@ -168,7 +168,12 @@ class AbstractCollection(Resource, Mapping):
                 return default
             return resource
         if self.unique_key is not None:
-            resource = self.connection.get_by_unique_key(self.unique_key, name)
+            # Give the storage a hint of which index to search.
+            # If this is a collection of an abstract type,
+            # the item_type will be None and we'll search all snovault indices.
+            index = getattr(self.type_info, 'item_type', None)
+            resource = self.connection.get_by_unique_key(
+                self.unique_key, name, index=index)
             if resource is not None:
                 if not self._allow_contained(resource):
                     return default

--- a/src/snovault/storage.py
+++ b/src/snovault/storage.py
@@ -93,7 +93,7 @@ class RDBStorage(object):
             return default
         return model
 
-    def get_by_unique_key(self, unique_key, name, default=None):
+    def get_by_unique_key(self, unique_key, name, default=None, index=None):
         session = self.DBSession()
         try:
             key = baked_query_unique_key(session).params(name=unique_key, value=name).one()


### PR DESCRIPTION
This will hopefully improve performance for fetching single objects at their canonical URI.

This is based on the changes from #93 so you can check the cumulative performance improvement in a demo -- start one from the SNO-33-one-index branch of `encoded`, which uses this snovault branch. Look at the more recent commit to see just the changes related to SNO-33.

Note that this involves a small change to the interface for storages -- the `get_by_unique_key` method must now take an optional `index` parameter.