### PR TITLE
SNO-34-attachment-download

### DIFF
--- a/src/snovault/attachment.py
+++ b/src/snovault/attachment.py
@@ -5,6 +5,7 @@ from mimetypes import guess_type
 from PIL import Image
 from pyramid.httpexceptions import (
     HTTPNotFound,
+    HTTPTemporaryRedirect,
 )
 from pyramid.response import Response
 from pyramid.traversal import find_root
@@ -207,6 +208,8 @@ def download(context, request):
     blob_storage = request.registry[BLOBS]
     if hasattr(blob_storage, 'get_blob_url'):
         blob_url = blob_storage.get_blob_url(download_meta)
+        if request.client_addr not in request.registry['aws_ipset']:
+            raise HTTPTemporaryRedirect(location=blob_url)
         return Response(headers={'X-Accel-Redirect': '/_proxy/' + str(blob_url)})
 
     # Otherwise serve the blob data ourselves


### PR DESCRIPTION
This allows for protected documents to be downloaded regardless of auth parameter passed into the request. 