### PR TITLE
SNO-34-nginx-dev-proxy-headers

### DIFF
--- a/src/snovault/nginx-dev.conf
+++ b/src/snovault/nginx-dev.conf
@@ -26,6 +26,8 @@ http {
         }
       location ~ ^/_proxy/(.*)$ {
           internal;
+          proxy_set_header Authorization "";
+          proxy_set_header Content-Type "";
           proxy_buffering off;
           proxy_pass $1$is_args$args;
       }


### PR DESCRIPTION
This removes authorization and content-type headers from nginx-dev config.