### PR TITLE
SNO-40-upgrade-boto3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ requires = [
     'SQLAlchemy>=1.0.0b1',
     'WSGIProxy2',
     'WebTest',
-    'boto',
     'botocore',
     'jmespath',
     'boto3',

--- a/src/snovault/storage.py
+++ b/src/snovault/storage.py
@@ -49,9 +49,7 @@ def includeme(config):
     _DBSESSION = registry[DBSESSION]
     if registry.settings.get('blob_bucket'):
         registry[BLOBS] = S3BlobStorage(
-            registry.settings['blob_bucket'],
-            read_profile_name=registry.settings.get('blob_read_profile_name'),
-            store_profile_name=registry.settings.get('blob_store_profile_name'),
+            registry.settings['blob_bucket']
         )
     else:
         registry[BLOBS] = RDBBlobStorage(registry[DBSESSION])

--- a/src/snovault/storage.py
+++ b/src/snovault/storage.py
@@ -32,7 +32,8 @@ from .interfaces import (
     STORAGE,
 )
 from .json_renderer import json_renderer
-import boto
+import boto3
+import botocore
 import json
 import transaction
 import uuid
@@ -298,22 +299,32 @@ class RDBBlobStorage(object):
 
 
 class S3BlobStorage(object):
-    def __init__(self, bucket, read_profile_name=None, store_profile_name=None):
-        self.store_conn = boto.connect_s3(profile_name=store_profile_name)
-        self.read_conn = boto.connect_s3(profile_name=read_profile_name)
-        self.bucket = self.store_conn.get_bucket(bucket, validate=False)
+    def __init__(self, bucket):
+        self.resource = boto3.resource('s3')
+        # Have to use client API for presigned_url.
+        self.client = boto3.client('s3')
+        self.bucket = self.resource.Bucket(bucket)
 
     def store_blob(self, data, download_meta, blob_id=None):
         if blob_id is None:
             blob_id = str(uuid.uuid4())
             key = None
         else:
-            key = self.bucket.get_key(blob_id)
+            # Have to check existence manually with boto3.
+            try:
+                key = self.resource.Object(self.bucket.name, blob_id).get()
+            except botocore.exceptions.ClientError as e:
+                # Possible that UUID exists but is not in bucket during migration.
+                if e.response['Error']['Code'] == 'NoSuchKey':
+                    key = None
+                else:
+                    raise
         if key is None:
-            key = self.bucket.new_key(blob_id)
-            if 'type' in download_meta:
-                key.content_type = download_meta['type']
-            key.set_contents_from_string(data)
+            self.resource.Bucket(self.bucket.name).put_object(
+                Key=blob_id,
+                Body=data,
+                ContentType=download_meta.get('type', 'application/octet-stream')
+            )
         download_meta['bucket'] = self.bucket.name
         download_meta['key'] = blob_id
 
@@ -326,15 +337,19 @@ class S3BlobStorage(object):
 
     def get_blob_url(self, download_meta):
         bucket_name, key = self._get_bucket_key(download_meta)
-        location = self.read_conn.generate_url(
-            36*60*60, method='GET', bucket=bucket_name, key=key)
+        location = self.client.generate_presigned_url(
+            ClientMethod='get_object',
+            Params={
+                'Bucket': bucket_name,
+                'Key': key
+            },
+            ExpiresIn=36*60*60
+        )
         return location
 
     def get_blob(self, download_meta):
         bucket_name, key = self._get_bucket_key(download_meta)
-        bucket = self.read_conn.get_bucket(bucket_name, validate=False)
-        key_obj = bucket.get_key(key, validate=False)
-        return key_obj.get_contents_as_string()
+        return self.resource.Object(bucket_name, key).get()['Body'].read()
 
 
 class JSON(types.TypeDecorator):

--- a/versions.cfg
+++ b/versions.cfg
@@ -248,7 +248,7 @@ hexagonit.recipe.download = 1.7.1
 # elasticsearch = 5.4.1
 
 # Added by buildout at 2017-05-03 00:28:43.399766s
-s3transfer = 1.11.0
+s3transfer = 0.1.13
 
 # Required by:
 # encoded==0.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -196,7 +196,7 @@ zope.sqlalchemy = 0.7.6
 
 # Added by buildout at 2016-03-26 11:24:23.268932
 colorama = 0.3.3
-docutils = 0.14
+docutils = 0.12
 pyasn1 = 0.1.9
 python-dateutil = 2.5.1
 rsa = 3.3
@@ -207,7 +207,7 @@ rsa = 3.3
 
 # Required by:
 # encoded==0.1
-jmespath = 0.9.3
+jmespath = 0.9.0
 
 # Required by:
 # WSGIProxy2==0.4.2
@@ -248,19 +248,21 @@ hexagonit.recipe.download = 1.7.1
 # elasticsearch = 5.4.1
 
 # Added by buildout at 2017-05-03 00:28:43.399766s
-s3transfer = 0.1.13
+s3transfer = 0.1.10
 
 # Required by:
 # encoded==0.1
-boto3 = 1.7.29
+boto3 = 1.4.4
 
 # Required by:
 # encoded==0.1
-botocore = 1.10.29
+botocore = 1.5.45
 
 # Added by buildout at 2017-05-03 01:56:14.054101
 PyYAML = 3.12
 awscli = 1.11.82
+
+# Added by buildout at 2017-07-11 20:26:47.501784
 
 # Required by:
 # encoded==0.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -196,7 +196,7 @@ zope.sqlalchemy = 0.7.6
 
 # Added by buildout at 2016-03-26 11:24:23.268932
 colorama = 0.3.3
-docutils = 0.12
+docutils = 0.14
 pyasn1 = 0.1.9
 python-dateutil = 2.5.1
 rsa = 3.3
@@ -207,7 +207,7 @@ rsa = 3.3
 
 # Required by:
 # encoded==0.1
-jmespath = 0.9.0
+jmespath = 0.9.3
 
 # Required by:
 # WSGIProxy2==0.4.2
@@ -248,25 +248,19 @@ hexagonit.recipe.download = 1.7.1
 # elasticsearch = 5.4.1
 
 # Added by buildout at 2017-05-03 00:28:43.399766s
-s3transfer = 0.1.10
+s3transfer = 1.11.0
 
 # Required by:
 # encoded==0.1
-boto3 = 1.4.4
+boto3 = 1.7.29
 
 # Required by:
 # encoded==0.1
-botocore = 1.5.45
+botocore = 1.10.29
 
 # Added by buildout at 2017-05-03 01:56:14.054101
 PyYAML = 3.12
 awscli = 1.11.82
-
-# Added by buildout at 2017-07-11 20:26:47.501784
-
-# Required by:
-# encoded==0.1
-boto = 2.48.0
 
 # Required by:
 # encoded==0.1

--- a/versions.cfg
+++ b/versions.cfg
@@ -262,12 +262,6 @@ botocore = 1.5.45
 PyYAML = 3.12
 awscli = 1.11.82
 
-# Added by buildout at 2017-07-11 20:26:47.501784
-
-# Required by:
-# encoded==0.1
-boto = 2.48.0
-
 # Required by:
 # encoded==0.1
 elasticsearch = 5.4.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -264,4 +264,8 @@ awscli = 1.11.82
 
 # Required by:
 # encoded==0.1
+boto = 2.48.0
+
+# Required by:
+# encoded==0.1
 elasticsearch = 5.4.0


### PR DESCRIPTION
This tries to recreate the boto functionality in S3BlobStorage with boto3. Several boto methods don't have equivalent methods in boto3. The storage parameters `read_profile_name=None, store_profile_name=None` never seemed to be used so removed. The `store_conn` and `read_conn` abstractions likewise didn't seem useful to recreate.