### PR TITLE
SNO-46 Remove unused search type arg

### DIFF
--- a/src/snowflakes/search.py
+++ b/src/snowflakes/search.py
@@ -618,9 +618,12 @@ def search(context, request, return_generator=False):
     search_term = prepare_search_term(request)
 
     ## converts type= query parameters to list of doc_types to search, "*" becomes super class Item
-    doc_types = request.params.getall('type')
-    if '*' in doc_types:
-        doc_types = ['Item']
+    if context.type_info.name:
+        doc_types = [context.type_info.name]
+    else:
+        doc_types = request.params.getall('type')
+        if '*' in doc_types:
+            doc_types = ['Item']
 
     # Normalize to item_type
     try:
@@ -810,7 +813,7 @@ def collection_view_listing_es(context, request):
     if request.datastore != 'elasticsearch':
         return collection_view_listing_db(context, request)
 
-    return search(context, request, context.type_info.name)
+    return search(context, request)
 
 
 @view_config(route_name='report', request_method='GET', permission='search')

--- a/src/snowflakes/search.py
+++ b/src/snowflakes/search.py
@@ -618,7 +618,9 @@ def search(context, request, return_generator=False):
     search_term = prepare_search_term(request)
 
     ## converts type= query parameters to list of doc_types to search, "*" becomes super class Item
-    if context.type_info.name:
+    if (hasattr(context, 'type_info') and
+            hasattr(context.type_info, 'name')
+            and context.type_info.name):
         doc_types = [context.type_info.name]
     else:
         doc_types = request.params.getall('type')

--- a/src/snowflakes/search.py
+++ b/src/snowflakes/search.py
@@ -589,7 +589,7 @@ def iter_long_json(name, iterable, other):
         yield ']' + other_stuff + '}'
 
 @view_config(route_name='search', request_method='GET', permission='search')
-def search(context, request, search_type=None, return_generator=False):
+def search(context, request, return_generator=False):
     """
     Search view connects to ElasticSearch and returns the results
     """
@@ -618,13 +618,9 @@ def search(context, request, search_type=None, return_generator=False):
     search_term = prepare_search_term(request)
 
     ## converts type= query parameters to list of doc_types to search, "*" becomes super class Item
-    if search_type is None:
-        doc_types = request.params.getall('type')
-        if '*' in doc_types:
-            doc_types = ['Item']
-
-    else:
-        doc_types = [search_type]
+    doc_types = request.params.getall('type')
+    if '*' in doc_types:
+        doc_types = ['Item']
 
     # Normalize to item_type
     try:


### PR DESCRIPTION
Ben or I could not find where this search_type arg was ever used.  It can't be added as a query parameter because it wasn't set up properly.  Is was in the way for search refactor epic so we're removing it.

ENCD-4154 for similar snowflakes updates