### PR TITLE
SNO-45-increase-embed-cache

### DIFF
--- a/src/snovault/connection.py
+++ b/src/snovault/connection.py
@@ -24,7 +24,7 @@ class Connection(object):
         self.registry = registry
         self.item_cache = ManagerLRUCache('snovault.connection.item_cache', 1000)
         self.unique_key_cache = ManagerLRUCache('snovault.connection.key_cache', 1000)
-        embed_cache_capacity = int(registry.settings.get('embed_cache.capacity', 2000))
+        embed_cache_capacity = int(registry.settings.get('embed_cache.capacity', 5000))
         self.embed_cache = ManagerLRUCache('snovault.connection.embed_cache', embed_cache_capacity)
     @reify
     def storage(self):


### PR DESCRIPTION
Increasing embed cache size for loading large objects (like publication-data) with a lot of files.