### PR TITLE
SNO-47 Add index time log option and update index output data

### DIFF
--- a/src/snovault/elasticsearch/index_logger.py
+++ b/src/snovault/elasticsearch/index_logger.py
@@ -63,7 +63,7 @@ class IndexLogger(object):
         if 'es_time' in output and isinstance(output['es_time'], float):
             output['es_time'] = '%0.6f' % output['es_time']
         self.write_log(
-            '{timestamp} {doc_path} '
+            '{timestamp} {doc_path} {doc_type} '
             '{embed_time} {embed_ecp} '
             '{es_time} {es_ecp} '
             '{embeds} {linked} '
@@ -75,6 +75,7 @@ class IndexLogger(object):
                 es_ecp=output.get('es_ecp'),
                 doc_path=output.get('doc_path'),
                 linked=output.get('doc_linked'),
+                doc_type=output.get('doc_type'),
                 timestamp=output.get('timestamp'),
             )
         )
@@ -89,8 +90,8 @@ class IndexLogger(object):
             )
         )
         self.write_log(
-            'date time timestamp doc_path embed_time embed_ecp '
-            'es_time es_ecp embeds linked'
+            'date time timestamp doc_path doc_type '
+            'embed_time embed_ecp es_time es_ecp embeds linked'
         )
 
     def write_log(self, msg, uuid=None, start_time=None):

--- a/src/snovault/elasticsearch/index_logger.py
+++ b/src/snovault/elasticsearch/index_logger.py
@@ -68,13 +68,13 @@ class IndexLogger(object):
             '{es_time} {es_ecp} '
             '{embeds} {linked} '
             ''.format(
-                embeds=output.get('doc_embedded_uuids'),
+                embeds=output.get('doc_embedded'),
                 embed_ecp=output.get('embed_ecp'),
                 embed_time=output.get('embed_time'),
                 es_time=output.get('es_time'),
                 es_ecp=output.get('es_ecp'),
-                doc_path=output.get('doc_paths_zero'),
-                linked=output.get('doc_linked_uuids'),
+                doc_path=output.get('doc_path'),
+                linked=output.get('doc_linked'),
                 timestamp=output.get('timestamp'),
             )
         )

--- a/src/snovault/elasticsearch/index_logger.py
+++ b/src/snovault/elasticsearch/index_logger.py
@@ -28,6 +28,7 @@ class IndexLogger(object):
 
     def _get_log(self):
         if self._do_log:
+            # Timestamp converted to micro seconds to separate index logs
             file_name = "{}-{}.log".format(
                 self.log_name,
                 str(int(time.time() * 10000000)),

--- a/src/snovault/elasticsearch/index_logger.py
+++ b/src/snovault/elasticsearch/index_logger.py
@@ -63,7 +63,7 @@ class IndexLogger(object):
         if 'es_time' in output and isinstance(output['es_time'], float):
             output['es_time'] = '%0.6f' % output['es_time']
         self.write_log(
-            '{timestamp} {doc_path} {doc_type} '
+            '{start_time} {end_timestamp} {doc_path} {doc_type} '
             '{embed_time} {embed_ecp} '
             '{es_time} {es_ecp} '
             '{embeds} {linked} '
@@ -71,12 +71,13 @@ class IndexLogger(object):
                 embeds=output.get('doc_embedded'),
                 embed_ecp=output.get('embed_ecp'),
                 embed_time=output.get('embed_time'),
+                end_timestamp=output.get('end_timestamp'),
                 es_time=output.get('es_time'),
                 es_ecp=output.get('es_ecp'),
                 doc_path=output.get('doc_path'),
-                linked=output.get('doc_linked'),
                 doc_type=output.get('doc_type'),
-                timestamp=output.get('timestamp'),
+                linked=output.get('doc_linked'),
+                start_time=output.get('start_time'),
             )
         )
 
@@ -90,7 +91,7 @@ class IndexLogger(object):
             )
         )
         self.write_log(
-            'date time timestamp doc_path doc_type '
+            'start_time end_timestamp doc_path doc_type '
             'embed_time embed_ecp es_time es_ecp embeds linked'
         )
 

--- a/src/snovault/elasticsearch/index_logger.py
+++ b/src/snovault/elasticsearch/index_logger.py
@@ -88,6 +88,10 @@ class IndexLogger(object):
                 len_uuids, xmin, snapshot_id,
             )
         )
+        self.write_log(
+            'date time timestamp doc_path embed_time embed_ecp '
+            'es_time es_ecp embeds linked'
+        )
 
     def write_log(self, msg, uuid=None, start_time=None):
         '''Handles all logging message'''

--- a/src/snovault/elasticsearch/index_logger.py
+++ b/src/snovault/elasticsearch/index_logger.py
@@ -10,7 +10,7 @@ import time
 class IndexLogger(object):
     '''Basic Logger tailored to our indexing process'''
     log_name = 'indexing_time'
-    log_path = '/srv/encoded/develop/snovault/src/snovault/elasticsearch'
+    log_path = './src/snovault/elasticsearch'
 
     def __init__(self, do_log=False, log_name=None, log_path=None):
         self._do_log = do_log

--- a/src/snovault/elasticsearch/index_logger.py
+++ b/src/snovault/elasticsearch/index_logger.py
@@ -52,8 +52,8 @@ class IndexLogger(object):
         * Logger gets logs name so we call twice to clear and get a new one
         '''
         if self._do_log:
-            self._the_log = self._get_log()
-            self._close_handlers()
+            if self._the_log:
+                self._close_handlers()
             self._the_log = self._get_log()
 
     def append_output(self, output):

--- a/src/snovault/elasticsearch/index_logger.py
+++ b/src/snovault/elasticsearch/index_logger.py
@@ -10,7 +10,7 @@ import time
 class IndexLogger(object):
     '''Basic Logger tailored to our indexing process'''
     log_name = 'indexing_time'
-    log_path = './src/snovault/elasticsearch'
+    log_path = './'
 
     def __init__(self, do_log=False, log_name=None, log_path=None):
         self._do_log = do_log

--- a/src/snovault/elasticsearch/index_logger.py
+++ b/src/snovault/elasticsearch/index_logger.py
@@ -1,0 +1,98 @@
+"""
+Indexing Data Log
+
+* Logs uuid progress, timing, and exceptions as they happen.
+"""
+import logging
+import time
+
+
+class IndexLogger(object):
+    '''Basic Logger tailored to our indexing process'''
+    log_name = 'indexing_time'
+    log_path = '/srv/encoded/develop/snovault/src/snovault/elasticsearch'
+
+    def __init__(self, do_log=False, log_name=None, log_path=None):
+        self._do_log = do_log
+        if log_name:
+            self.log_name = log_name
+        if log_path:
+            self.log_path = log_path
+        self._the_log = None
+
+    def _close_handlers(self):
+        '''Close all log handlers'''
+        for handler in self._the_log.handlers:
+            handler.close()
+            self._the_log.removeHandler(handler)
+
+    def _get_log(self):
+        if self._do_log:
+            file_name = "{}-{}.log".format(
+                self.log_name,
+                str(int(time.time() * 10000000)),
+            )
+            file_path = "{}/{}".format(self.log_path, file_name)
+            level = logging.INFO
+            formatter_str = '%(asctime)s %(message)s'
+            log = logging.getLogger(self.log_name)
+            hanlder = logging.FileHandler(file_path)
+            formatter = logging.Formatter(formatter_str)
+            hanlder.setFormatter(formatter)
+            log.addHandler(hanlder)
+            log.setLevel(level)
+            return log
+        return None
+
+    def _reset_log(self):
+        '''
+        Close handlers and Get new log
+
+        * Logger gets logs name so we call twice to clear and get a new one
+        '''
+        if self._do_log:
+            self._the_log = self._get_log()
+            self._close_handlers()
+            self._the_log = self._get_log()
+
+    def append_output(self, output):
+        '''Log the output dict from the Indexer.update_object class'''
+        if 'embed_time' in output and isinstance(output['embed_time'], float):
+            output['embed_time'] = '%0.6f' % output['embed_time']
+        if 'es_time' in output and isinstance(output['es_time'], float):
+            output['es_time'] = '%0.6f' % output['es_time']
+        self.write_log(
+            '{timestamp} {doc_path} '
+            '{embed_time} {embed_ecp} '
+            '{es_time} {es_ecp} '
+            '{embeds} {linked} '
+            ''.format(
+                embeds=output.get('doc_embedded_uuids'),
+                embed_ecp=output.get('embed_ecp'),
+                embed_time=output.get('embed_time'),
+                es_time=output.get('es_time'),
+                es_ecp=output.get('es_ecp'),
+                doc_path=output.get('doc_paths_zero'),
+                linked=output.get('doc_linked_uuids'),
+                timestamp=output.get('timestamp'),
+            )
+        )
+
+
+    def new_log(self, len_uuids, xmin, snapshot_id):
+        '''Reset log and add start message'''
+        self._reset_log()
+        self.write_log(
+            'Starting Indexing {} with xmin={} and snapshot_id={}'.format(
+                len_uuids, xmin, snapshot_id,
+            )
+        )
+
+    def write_log(self, msg, uuid=None, start_time=None):
+        '''Handles all logging message'''
+        if self._the_log:
+            uuid = str(uuid) + ' ' if uuid else ''
+            diff = ''
+            if start_time:
+                diff = ' %0.6f' % (time.time() - start_time)
+            self._the_log.info("%s%s%s", uuid, msg, diff)

--- a/src/snovault/elasticsearch/indexer.py
+++ b/src/snovault/elasticsearch/indexer.py
@@ -337,8 +337,8 @@ class Indexer(object):
         # OPTIONAL: restart support
 
         output = {
-            'doc_embedded_uuids': None,
-            'doc_linked_uuids': None,
+            'doc_embedded': None,
+            'doc_linked': None,
             'doc_path': None,
             'doc_type': None,
             'embed_ecp': None,

--- a/src/snovault/elasticsearch/indexer.py
+++ b/src/snovault/elasticsearch/indexer.py
@@ -313,7 +313,7 @@ class Indexer(object):
             if output['error_message'] is not None:
                 errors.append({
                     'error_message': output['error_message'],
-                    'timestamp': output['timestamp'],
+                    'timestamp': output['end_timestamp'],
                     'uuid': output['uuid'],
                 })
             if (i + 1) % 50 == 0:
@@ -346,11 +346,11 @@ class Indexer(object):
             'es_ecp': None,
             'es_time': None,
             'error_message': None,
+            'start_time': time.time(),
             'timestamp': None,
             'uuid': str(uuid),
         }
         try:
-            embed_start_time = time.time()
             doc = request.embed('/%s/@@index-data/' % uuid, as_user='INDEXER')
         except StatementError:
             # Can't reconnect until invalid transaction is rolled back
@@ -367,7 +367,7 @@ class Indexer(object):
             output['doc_type'] = doc.get('item_type')
             output['doc_embedded'] = len(doc.get('embedded_uuids', []))
             output['doc_linked'] = len(doc.get('linked_uuids', []))
-        output['embed_time'] = time.time() - embed_start_time
+        output['embed_time'] = time.time() - output['start_time']
 
         if output['error_message'] is None:
             for backoff in [0, 10, 20, 40, 80]:
@@ -405,7 +405,7 @@ class Indexer(object):
                     output['es_time'] = time.time() - es_start_time
                     break
 
-        output['timestamp'] = datetime.datetime.now().isoformat()
+        output['end_timestamp'] = datetime.datetime.now().isoformat()
         return output
 
     def shutdown(self):

--- a/src/snovault/elasticsearch/indexer.py
+++ b/src/snovault/elasticsearch/indexer.py
@@ -309,13 +309,14 @@ class Indexer(object):
         errors = []
         for i, uuid in enumerate(uuids):
             output = self.update_object(request, uuid, xmin)
-            self._indexer_log.append_output(output)
-            if output['error_message'] is not None:
-                errors.append({
-                    'error_message': output['error_message'],
-                    'timestamp': output['end_timestamp'],
-                    'uuid': output['uuid'],
-                })
+            if output:
+                self._indexer_log.append_output(output)
+                if output['error_message'] is not None:
+                    errors.append({
+                        'error_message': output['error_message'],
+                        'timestamp': output['end_timestamp'],
+                        'uuid': output['uuid'],
+                    })
             if (i + 1) % 50 == 0:
                 log.info('Indexing %d', i + 1)
 

--- a/src/snovault/elasticsearch/mpindexer.py
+++ b/src/snovault/elasticsearch/mpindexer.py
@@ -4,6 +4,7 @@ from multiprocessing import get_context
 from multiprocessing.pool import Pool
 from pyramid.decorator import reify
 from pyramid.request import apply_request_extensions
+from pyramid.settings import asbool
 from pyramid.threadlocal import (
     get_current_request,
     manager,
@@ -29,7 +30,10 @@ def includeme(config):
         processes = int(processes)
     except:
         processes = None
-    config.registry[INDEXER] = MPIndexer(config.registry, processes=processes)
+    do_log = False
+    if asbool(config.registry.settings.get('indexer')):
+        do_log = True
+    config.registry[INDEXER] = MPIndexer(config.registry, processes=processes, do_log=do_log)
 
 
 # Running in subprocess
@@ -112,8 +116,8 @@ def update_object_in_snapshot(args):
 class MPIndexer(Indexer):
     maxtasks = 1  # pooled processes will exit and be replaced after this many tasks are completed.
 
-    def __init__(self, registry, processes=None):
-        super(MPIndexer, self).__init__(registry)
+    def __init__(self, registry, processes=None, do_log=False):
+        super(MPIndexer, self).__init__(registry, do_log=do_log)
         self.processes = processes
         self.chunksize = int(registry.settings.get('indexer.chunk_size',1024))  # in production.ini (via buildout.cfg) as 1024
         self.initargs = (registry[APP_FACTORY], registry.settings,)
@@ -131,6 +135,7 @@ class MPIndexer(Indexer):
     def update_objects(self, request, uuids, xmin, snapshot_id, restart):
         # Ensure that we iterate over uuids in this thread not the pool task handler.
         uuid_count = len(uuids)
+        self._indexer_log.new_log(uuid_count, xmin, snapshot_id)
         workers = 1
         if self.processes is not None and self.processes > 0:
             workers = self.processes
@@ -142,6 +147,7 @@ class MPIndexer(Indexer):
         errors = []
         try:
             for i, output in enumerate(self.pool.imap_unordered(update_object_in_snapshot, tasks, chunkiness)):
+                self._indexer_log.append_output(output)
                 if output['error_message'] is not None:
                     errors.append({
                         'error_message': output['error_message'],

--- a/src/snovault/elasticsearch/mpindexer.py
+++ b/src/snovault/elasticsearch/mpindexer.py
@@ -141,10 +141,13 @@ class MPIndexer(Indexer):
         tasks = [(uuid, xmin, snapshot_id, restart) for uuid in uuids]
         errors = []
         try:
-            for i, error in enumerate(self.pool.imap_unordered(
-                    update_object_in_snapshot, tasks, chunkiness)):
-                if error is not None:
-                    errors.append(error)
+            for i, output in enumerate(self.pool.imap_unordered(update_object_in_snapshot, tasks, chunkiness)):
+                if output['error_message'] is not None:
+                    errors.append({
+                        'error_message': output['error_message'],
+                        'timestamp': output['timestamp'],
+                        'uuid': output['uuid'],
+                    })
                 if (i + 1) % 50 == 0:
                     log.info('Indexing %d', i + 1)
         except:

--- a/src/snovault/elasticsearch/mpindexer.py
+++ b/src/snovault/elasticsearch/mpindexer.py
@@ -151,7 +151,7 @@ class MPIndexer(Indexer):
                 if output['error_message'] is not None:
                     errors.append({
                         'error_message': output['error_message'],
-                        'timestamp': output['timestamp'],
+                        'timestamp': output['end_timestamp'],
                         'uuid': output['uuid'],
                     })
                 if (i + 1) % 50 == 0:

--- a/src/snovault/elasticsearch/mpindexer.py
+++ b/src/snovault/elasticsearch/mpindexer.py
@@ -148,12 +148,13 @@ class MPIndexer(Indexer):
         try:
             for i, output in enumerate(self.pool.imap_unordered(update_object_in_snapshot, tasks, chunkiness)):
                 self._indexer_log.append_output(output)
-                if output['error_message'] is not None:
-                    errors.append({
-                        'error_message': output['error_message'],
-                        'timestamp': output['end_timestamp'],
-                        'uuid': output['uuid'],
-                    })
+                if output:
+                    if output['error_message'] is not None:
+                        errors.append({
+                            'error_message': output['error_message'],
+                            'timestamp': output['end_timestamp'],
+                            'uuid': output['uuid'],
+                        })
                 if (i + 1) % 50 == 0:
                     log.info('Indexing %d', i + 1)
         except:

--- a/src/snovault/elasticsearch/tests/test_index_logger.py
+++ b/src/snovault/elasticsearch/tests/test_index_logger.py
@@ -31,7 +31,7 @@ def fake_index_uuid_output():
     '''Builds some fake output from the Indexer.update_object'''
     return {
         'error_message': 'fake-error_message',
-        'timestamp': 'fake-timestamp',
+        'end_timestamp': 'fake-end_timestamp',
         'uuid': 'fake-uuid',
         'es_time': 0.123,
         'es_ecp': 'fake-es_ecp',
@@ -41,6 +41,7 @@ def fake_index_uuid_output():
         'doc_type': 'fake-doc_type',
         'doc_embedded': 'fake-doc_embedded',
         'doc_linked': 'fake-doc_linked',
+        'start_time': 'fake-start_time',
     }
 
 
@@ -131,7 +132,7 @@ def test_log_on_write_new_append(index_logger_on, fake_index_uuid_output):
             lines.append(line.strip())
     assert len(lines) == 3
     expected_new_line = (
-        'fake-timestamp fake-doc_paths_zero 0.456000 '
+        'fake-start_time fake-end_timestamp fake-doc_paths_zero 0.456000 '
         'fake-embed_ecp 0.123000 fake-es_ecp '
         'fake-doc_embedded_uuids fake-doc_linked_uuids'
     )
@@ -141,14 +142,14 @@ def test_log_on_write_new_append(index_logger_on, fake_index_uuid_output):
     )
     assert  new_line == expected_new_line
     expected_title_line = (
-        'date time timestamp doc_path doc_type '
+        'start_time end_timestamp doc_path doc_type '
         'embed_time embed_ecp es_time es_ecp '
         'embeds linked'
     )
     title_line = lines[1].split(' ', 2)[-1]
     assert  title_line == expected_title_line
     expected_append_line = (
-        'fake-timestamp fake-doc_path fake-doc_type '
+        'fake-start_time fake-end_timestamp fake-doc_path fake-doc_type '
         '0.456000 fake-embed_ecp 0.123000 fake-es_ecp '
         'fake-doc_embedded fake-doc_linked'
     )

--- a/src/snovault/elasticsearch/tests/test_index_logger.py
+++ b/src/snovault/elasticsearch/tests/test_index_logger.py
@@ -56,7 +56,7 @@ def test_log_off_init(index_logger_off):
     assert hasattr(index_logger_off, 'log_path')
     assert (
         getattr(index_logger_off, 'log_path') ==
-        './src/snovault/elasticsearch'
+        './'
     )
     # pylint: disable=protected-access
     assert index_logger_off._get_log() is None

--- a/src/snovault/elasticsearch/tests/test_index_logger.py
+++ b/src/snovault/elasticsearch/tests/test_index_logger.py
@@ -141,14 +141,15 @@ def test_log_on_write_new_append(index_logger_on, fake_index_uuid_output):
     )
     assert  new_line == expected_new_line
     expected_title_line = (
-        'date time timestamp doc_path embed_time embed_ecp '
-        'es_time es_ecp embeds linked'
+        'date time timestamp doc_path doc_type '
+        'embed_time embed_ecp es_time es_ecp '
+        'embeds linked'
     )
     title_line = lines[1].split(' ', 2)[-1]
     assert  title_line == expected_title_line
     expected_append_line = (
-        'fake-timestamp fake-doc_path 0.456000 '
-        'fake-embed_ecp 0.123000 fake-es_ecp '
+        'fake-timestamp fake-doc_path fake-doc_type '
+        '0.456000 fake-embed_ecp 0.123000 fake-es_ecp '
         'fake-doc_embedded fake-doc_linked'
     )
     append_line = lines[2].split(' ', 2)[-1]

--- a/src/snovault/elasticsearch/tests/test_index_logger.py
+++ b/src/snovault/elasticsearch/tests/test_index_logger.py
@@ -56,7 +56,7 @@ def test_log_off_init(index_logger_off):
     assert hasattr(index_logger_off, 'log_path')
     assert (
         getattr(index_logger_off, 'log_path') ==
-        '/srv/encoded/develop/snovault/src/snovault/elasticsearch'
+        './src/snovault/elasticsearch'
     )
     # pylint: disable=protected-access
     assert index_logger_off._get_log() is None

--- a/src/snovault/elasticsearch/tests/test_index_logger.py
+++ b/src/snovault/elasticsearch/tests/test_index_logger.py
@@ -1,0 +1,149 @@
+"""Tests and Fixtures for testing elasticsearch.indexer_log"""
+import logging
+import pytest # pylint: disable=import-error
+
+
+TMP_DIR = 'tmp-index-logger-dir'
+TEST_FILENAME = 'test_indexing_time'
+
+
+@pytest.fixture
+def index_logger_off():
+    '''Returns default IndexerLog with do_log=False'''
+    from snovault.elasticsearch.index_logger import IndexLogger
+    return IndexLogger()
+
+
+@pytest.fixture
+def index_logger_on(tmpdir):
+    '''Returns default IndexerLog with do_log=False'''
+    from snovault.elasticsearch.index_logger import IndexLogger
+    index_logger = IndexLogger(
+        do_log=True,
+        log_name=TEST_FILENAME,
+        log_path=str(tmpdir.mkdir(TMP_DIR)),
+    )
+    return index_logger
+
+
+@pytest.fixture
+def fake_index_uuid_output():
+    '''Builds some fake output from the Indexer.update_object'''
+    return {
+        'error_message': 'fake-error_message',
+        'timestamp': 'fake-timestamp',
+        'uuid': 'fake-uuid',
+        'es_time': 0.123,
+        'es_ecp': 'fake-es_ecp',
+        'embed_time': 0.456,
+        'embed_ecp': 'fake-embed_ecp',
+        'doc_paths_zero':'fake-doc_paths_zero',
+        'doc_item_type': 'fake-doc_item_type',
+        'doc_embedded_uuids': 'fake-doc_embedded_uuids',
+        'doc_linked_uuids': 'fake-doc_linked_uuids',
+    }
+
+
+# pylint: disable=redefined-outer-name
+def test_log_off_init(index_logger_off):
+    '''Test the default OFF index log'''
+    assert hasattr(index_logger_off, '_do_log')
+    assert getattr(index_logger_off, '_do_log') is False
+    assert hasattr(index_logger_off, '_the_log')
+    assert getattr(index_logger_off, '_the_log') is None
+    assert hasattr(index_logger_off, 'log_name')
+    assert getattr(index_logger_off, 'log_name') == 'indexing_time'
+    assert hasattr(index_logger_off, 'log_path')
+    assert (
+        getattr(index_logger_off, 'log_path') ==
+        '/srv/encoded/develop/snovault/src/snovault/elasticsearch'
+    )
+    # pylint: disable=protected-access
+    assert index_logger_off._get_log() is None
+
+
+# pylint: disable=redefined-outer-name
+def test_log_off_bad_output(index_logger_off):
+    '''
+    Test the default OFF index log does break with bad output
+    '''
+    return_value = index_logger_off.append_output({})
+    assert return_value is None
+
+
+# pylint: disable=redefined-outer-name
+def test_log_off_pass_public(index_logger_off):
+    '''
+    Test the default OFF index log does break on public functions
+
+    * append_output function is tested in test_log_off_bad_output
+    '''
+    assert index_logger_off._the_log is None
+    new_log_return = index_logger_off.new_log(
+            'a uuid_len', 'a xmin', 'a snapshot_id')
+    assert new_log_return is None
+    write_log_return = index_logger_off.write_log('some msg')
+    assert write_log_return is None
+
+
+# pylint: disable=redefined-outer-name
+def test_log_on(index_logger_on):
+    '''Test the ON index log with edited init args'''
+    assert hasattr(index_logger_on, '_do_log')
+    assert getattr(index_logger_on, '_do_log') is True
+    assert hasattr(index_logger_on, '_the_log')
+    assert getattr(index_logger_on, '_the_log') is None
+    assert hasattr(index_logger_on, 'log_name')
+    assert getattr(index_logger_on, 'log_name') == TEST_FILENAME
+    assert hasattr(index_logger_on, 'log_path')
+    assert TMP_DIR in getattr(index_logger_on, 'log_path')
+
+
+# pylint: disable=redefined-outer-name
+def test_log_on_close_reset_get(index_logger_on):
+    '''
+    Test the ON index _close_handlers, _reset_log, and _get_log functions
+
+    * The log name does not change so we need to reset
+    '''
+    # pylint: disable=protected-access
+    index_logger_on._reset_log()
+    assert isinstance(index_logger_on._the_log, logging.Logger)
+    assert len(index_logger_on._the_log.handlers) == 1
+    index_logger_on._close_handlers()
+    assert not  index_logger_on._the_log.handlers
+
+
+# pylint: disable=redefined-outer-name
+def test_log_on_write_new_append(index_logger_on, fake_index_uuid_output):
+    '''Test the ON index log new_log nd append output'''
+    # pylint: disable=protected-access
+    uuid_len = 5
+    xmin = 'fake-xmin'
+    snapshot_id = 'fake-snapshot_id'
+    index_logger_on.new_log(uuid_len, xmin, snapshot_id)
+    index_logger_on.append_output(fake_index_uuid_output)
+    log_handler = index_logger_on._the_log.handlers[0]
+    log_file_path = log_handler.baseFilename
+    lines = []
+    with open(log_file_path, 'r') as file_handler:
+        for line in file_handler.readlines():
+            lines.append(line.strip())
+    assert len(lines) == 2
+    expected_new_line = (
+        'fake-timestamp fake-doc_paths_zero 0.456000 '
+        'fake-embed_ecp 0.123000 fake-es_ecp '
+        'fake-doc_embedded_uuids fake-doc_linked_uuids'
+    )
+    new_line = lines[0].split(' ', 2)[-1]
+    expected_new_line = (
+        'Starting Indexing 5 with xmin=fake-xmin and snapshot_id=fake-snapshot_id'
+    )
+    assert  new_line == expected_new_line
+    expected_append_line = (
+        'fake-timestamp fake-doc_paths_zero 0.456000 '
+        'fake-embed_ecp 0.123000 fake-es_ecp '
+        'fake-doc_embedded_uuids fake-doc_linked_uuids'
+    )
+    append_line = lines[1].split(' ', 2)[-1]
+    assert  append_line == expected_append_line

--- a/src/snovault/elasticsearch/tests/test_index_logger.py
+++ b/src/snovault/elasticsearch/tests/test_index_logger.py
@@ -37,10 +37,10 @@ def fake_index_uuid_output():
         'es_ecp': 'fake-es_ecp',
         'embed_time': 0.456,
         'embed_ecp': 'fake-embed_ecp',
-        'doc_paths_zero':'fake-doc_paths_zero',
-        'doc_item_type': 'fake-doc_item_type',
-        'doc_embedded_uuids': 'fake-doc_embedded_uuids',
-        'doc_linked_uuids': 'fake-doc_linked_uuids',
+        'doc_path':'fake-doc_path',
+        'doc_type': 'fake-doc_type',
+        'doc_embedded': 'fake-doc_embedded',
+        'doc_linked': 'fake-doc_linked',
     }
 
 
@@ -129,7 +129,7 @@ def test_log_on_write_new_append(index_logger_on, fake_index_uuid_output):
     with open(log_file_path, 'r') as file_handler:
         for line in file_handler.readlines():
             lines.append(line.strip())
-    assert len(lines) == 2
+    assert len(lines) == 3
     expected_new_line = (
         'fake-timestamp fake-doc_paths_zero 0.456000 '
         'fake-embed_ecp 0.123000 fake-es_ecp '
@@ -140,10 +140,16 @@ def test_log_on_write_new_append(index_logger_on, fake_index_uuid_output):
         'Starting Indexing 5 with xmin=fake-xmin and snapshot_id=fake-snapshot_id'
     )
     assert  new_line == expected_new_line
-    expected_append_line = (
-        'fake-timestamp fake-doc_paths_zero 0.456000 '
-        'fake-embed_ecp 0.123000 fake-es_ecp '
-        'fake-doc_embedded_uuids fake-doc_linked_uuids'
+    expected_title_line = (
+        'date time timestamp doc_path embed_time embed_ecp '
+        'es_time es_ecp embeds linked'
     )
-    append_line = lines[1].split(' ', 2)[-1]
+    title_line = lines[1].split(' ', 2)[-1]
+    assert  title_line == expected_title_line
+    expected_append_line = (
+        'fake-timestamp fake-doc_path 0.456000 '
+        'fake-embed_ecp 0.123000 fake-es_ecp '
+        'fake-doc_embedded fake-doc_linked'
+    )
+    append_line = lines[2].split(' ', 2)[-1]
     assert  append_line == expected_append_line


### PR DESCRIPTION
This PR updates the Indexer.update_object function so it returns more information to update_objects.  This is the only way to get info back from update_object when running MPIndexer.update_objects since it's in sub processes.

Also this PR adds an index_logger class that is imported and added to indexer.py:Indexer class.  The logger is added to all indexers, viz, region, and primary but is only turned on in the primary indexer.  So includeme was updated in indexer.py and mpindexer.py.

I will add this to the ini configs so we can turn it on/off without changing repo code.