### PR TITLE
Make nginx dev config respect forwarded proto.

### DIFF
--- a/src/snovault/nginx-dev.conf
+++ b/src/snovault/nginx-dev.conf
@@ -11,6 +11,12 @@ http {
         server 127.0.0.1:6543;
         keepalive 10;
     }
+
+    map $http_x_forwarded_proto $forwarded_proto {
+        default $http_x_forwarded_proto;
+        ''      $scheme;
+    }
+
     server {
         listen  8000;
         location / {
@@ -20,7 +26,7 @@ http {
             }
             proxy_set_header  Host  $http_host;
             proxy_set_header  X-Forwarded-For    $proxy_add_x_forwarded_for;
-            proxy_set_header  X-Forwarded-Proto  $scheme;
+            proxy_set_header  X-Forwarded-Proto  $forwarded_proto;
             proxy_pass  http://app;
             proxy_set_header  Connection  "";
         }


### PR DESCRIPTION
This allows proxying from another nginx server useful when wanting to expose current development intstance through a cloud instance.