### PR TITLE
SNO-108-improve-search-new

### DIFF
--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 META_MAPPING = {
     '_all': {
         'enabled': False,
-        'analyzer': 'english'
+        'analyzer': 'standard'
     },
     'dynamic_templates': [
         {
@@ -55,7 +55,7 @@ NON_SUBSTRING_FIELDS = ['uuid', '@id', 'submitted_by', 'md5sum',
 KEYWORD_FIELDS = ['schema_version', 'uuid', 'accession', 'alternate_accessions',
                   'aliases', 'status', 'date_created', 'submitted_by',
                   'internal_status', 'target', 'biosample_type']
-TEXT_FIELDS = ['pipeline_error_detail', 'description', 'notes', 'summary', 'biosample_summary']
+TEXT_FIELDS = ['pipeline_error_detail', 'description', 'notes']
 
 
 def sorted_pairs_hook(pairs):
@@ -246,7 +246,7 @@ def es_mapping(mapping):
     return {
         '_all': {
             'enabled': True,
-            'analyzer': 'standard'
+            'analyzer': 'english'
         },
         'dynamic_templates': [
             {

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -227,7 +227,6 @@ def index_settings():
                             'lowercase',
                             'english_stop',
                             'english_stemmer',
-                            'lowercase',
                             'asciifolding',
                             'delimiter'
                         ]

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -187,9 +187,16 @@ def index_settings():
                     "english_possessive_stemmer": {
                         "type":       "stemmer",
                         "language":   "possessive_english"
+                    },
+                    'delimiter': {
+                        'type': 'word_delimiter',
+                        'catenate_all': True,
+                        'preserve_original': True,
+                        'stem_english_possessive': True
                     }
+                }
                 },
-                'analyzer': {
+            'analyzer': {
                     'default': {
                         'type': 'custom',
                         'tokenizer': 'whitespace',
@@ -209,6 +216,7 @@ def index_settings():
                             'english_stop',
                             'english_stemmer',
                             'asciifolding',
+                            'delimiter',
                             'substring'
                         ]
                     },
@@ -221,7 +229,8 @@ def index_settings():
                             'english_stop',
                             'english_stemmer',
                             'lowercase',
-                            'asciifolding'
+                            'asciifolding',
+                            'delimiter'
                         ]
                     },
                     'snovault_path_analyzer': {

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -183,7 +183,7 @@ def index_settings():
                         'tokenizer': 'whitespace',
                         'char_filter': 'html_strip',
                         'filter': [
-                            'standard',
+                            'english',
                             'lowercase',
                         ]
                     },
@@ -192,7 +192,7 @@ def index_settings():
                         'tokenizer': 'whitespace',
                         'char_filter': 'html_strip',
                         'filter': [
-                            'standard',
+                            'english',
                             'lowercase',
                             'asciifolding',
                             'substring'
@@ -202,7 +202,7 @@ def index_settings():
                         'type': 'custom',
                         'tokenizer': 'whitespace',
                         'filter': [
-                            'standard',
+                            'english',
                             'lowercase',
                             'asciifolding'
                         ]
@@ -246,7 +246,8 @@ def es_mapping(mapping):
     return {
         '_all': {
             'enabled': True,
-            'analyzer': 'english'
+            'analyzer': 'snovault_index_analyzer',
+            'search_analyzer': 'snovault_search_analyzer'
         },
         'dynamic_templates': [
             {

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -175,6 +175,18 @@ def index_settings():
                         'type': 'nGram',
                         'min_gram': 1,
                         'max_gram': 33
+                    },
+                    "english_stop": {
+                        "type":       "stop",
+                        "stopwords":  "_english_"
+                    },
+                    "english_stemmer": {
+                        "type":       "stemmer",
+                        "language":   "english"
+                    },
+                    "english_possessive_stemmer": {
+                        "type":       "stemmer",
+                        "language":   "possessive_english"
                     }
                 },
                 'analyzer': {
@@ -183,7 +195,7 @@ def index_settings():
                         'tokenizer': 'whitespace',
                         'char_filter': 'html_strip',
                         'filter': [
-                            'english',
+                            'standard',
                             'lowercase',
                         ]
                     },
@@ -192,8 +204,10 @@ def index_settings():
                         'tokenizer': 'whitespace',
                         'char_filter': 'html_strip',
                         'filter': [
-                            'english',
+                            'english_possessive_stemmer',
                             'lowercase',
+                            'english_stop',
+                            'english_stemmer',
                             'asciifolding',
                             'substring'
                         ]
@@ -202,7 +216,10 @@ def index_settings():
                         'type': 'custom',
                         'tokenizer': 'whitespace',
                         'filter': [
-                            'english',
+                            'english_possessive_stemmer',
+                            'lowercase',
+                            'english_stop',
+                            'english_stemmer',
                             'lowercase',
                             'asciifolding'
                         ]

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -56,7 +56,13 @@ NON_SUBSTRING_FIELDS = ['uuid', '@id', 'submitted_by', 'md5sum',
 KEYWORD_FIELDS = ['schema_version', 'uuid', 'accession', 'alternate_accessions',
                   'aliases', 'status', 'date_created', 'submitted_by',
                   'internal_status', 'target', 'biosample_type']
-TEXT_FIELDS = ['pipeline_error_detail', 'description', 'notes']
+TEXT_FIELDS = [
+    'pipeline_error_detail',
+    'description',
+    'notes',
+    'summary',
+    'biosample_summary'
+]
 
 
 def sorted_pairs_hook(pairs):

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 META_MAPPING = {
     '_all': {
         'enabled': False,
-        'analyzer': 'standard'
+        'analyzer': 'english'
     },
     'dynamic_templates': [
         {

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -176,17 +176,17 @@ def index_settings():
                         'min_gram': 1,
                         'max_gram': 33
                     },
-                    "english_stop": {
-                        "type":       "stop",
-                        "stopwords":  "_english_"
+                    'english_stop': {
+                        'type': 'stop',
+                        'stopwords': '_english_'
                     },
-                    "english_stemmer": {
-                        "type":       "stemmer",
-                        "language":   "english"
+                    'english_stemmer': {
+                        'type': 'stemmer',
+                        'language': 'english'
                     },
-                    "english_possessive_stemmer": {
-                        "type":       "stemmer",
-                        "language":   "possessive_english"
+                    'english_possessive_stemmer': {
+                        'type': 'stemmer',
+                        'language': 'possessive_english'
                     },
                     'delimiter': {
                         'type': 'word_delimiter',

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -33,8 +33,7 @@ log = logging.getLogger(__name__)
 META_MAPPING = {
     '_all': {
         'enabled': False,
-        'analyzer': 'snovault_index_analyzer',
-        'search_analyzer': 'snovault_search_analyzer'
+        'analyzer': 'standard'
     },
     'dynamic_templates': [
         {
@@ -247,8 +246,7 @@ def es_mapping(mapping):
     return {
         '_all': {
             'enabled': True,
-            'analyzer': 'snovault_index_analyzer',
-            'search_analyzer': 'snovault_search_analyzer'
+            'analyzer': 'standard'
         },
         'dynamic_templates': [
             {

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -199,7 +199,8 @@ def index_settings():
                         'type': 'word_delimiter',
                         'catenate_all': True,
                         'preserve_original': True,
-                        'stem_english_possessive': True
+                        'stem_english_possessive': True,
+                        'split_on_numerics': False
                     }
                 },
                 'analyzer': {

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -33,7 +33,8 @@ log = logging.getLogger(__name__)
 META_MAPPING = {
     '_all': {
         'enabled': False,
-        'analyzer': 'standard'
+        'analyzer': 'snovault_index_analyzer',
+        'search_analyzer': 'snovault_search_analyzer'
     },
     'dynamic_templates': [
         {

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -56,7 +56,7 @@ NON_SUBSTRING_FIELDS = ['uuid', '@id', 'submitted_by', 'md5sum',
 KEYWORD_FIELDS = ['schema_version', 'uuid', 'accession', 'alternate_accessions',
                   'aliases', 'status', 'date_created', 'submitted_by',
                   'internal_status', 'target', 'biosample_type']
-TEXT_FIELDS = ['pipeline_error_detail', 'description', 'notes']
+TEXT_FIELDS = ['pipeline_error_detail', 'description', 'notes', 'summary', 'biosample_summary']
 
 
 def sorted_pairs_hook(pairs):

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -202,8 +202,12 @@ def index_settings():
                         'tokenizer': 'whitespace',
                         'char_filter': 'html_strip',
                         'filter': [
-                            'standard',
+                            'english_possessive_stemmer',
                             'lowercase',
+                            'english_stop',
+                            'english_stemmer',
+                            'asciifolding',
+                            'delimiter'
                         ]
                     },
                     'snovault_index_analyzer': {

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -55,7 +55,7 @@ NON_SUBSTRING_FIELDS = ['uuid', '@id', 'submitted_by', 'md5sum',
 KEYWORD_FIELDS = ['schema_version', 'uuid', 'accession', 'alternate_accessions',
                   'aliases', 'status', 'date_created', 'submitted_by',
                   'internal_status', 'target', 'biosample_type']
-TEXT_FIELDS = ['pipeline_error_detail', 'description', 'notes']
+TEXT_FIELDS = ['pipeline_error_detail', 'description', 'notes', 'summary', 'biosample_summary']
 
 
 def sorted_pairs_hook(pairs):

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -56,13 +56,7 @@ NON_SUBSTRING_FIELDS = ['uuid', '@id', 'submitted_by', 'md5sum',
 KEYWORD_FIELDS = ['schema_version', 'uuid', 'accession', 'alternate_accessions',
                   'aliases', 'status', 'date_created', 'submitted_by',
                   'internal_status', 'target', 'biosample_type']
-TEXT_FIELDS = [
-    'pipeline_error_detail',
-    'description',
-    'notes',
-    'summary',
-    'biosample_summary'
-]
+TEXT_FIELDS = ['pipeline_error_detail', 'description', 'notes']
 
 
 def sorted_pairs_hook(pairs):

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -194,9 +194,8 @@ def index_settings():
                         'preserve_original': True,
                         'stem_english_possessive': True
                     }
-                }
                 },
-            'analyzer': {
+                'analyzer': {
                     'default': {
                         'type': 'custom',
                         'tokenizer': 'whitespace',

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -55,7 +55,7 @@ NON_SUBSTRING_FIELDS = ['uuid', '@id', 'submitted_by', 'md5sum',
 KEYWORD_FIELDS = ['schema_version', 'uuid', 'accession', 'alternate_accessions',
                   'aliases', 'status', 'date_created', 'submitted_by',
                   'internal_status', 'target', 'biosample_type']
-TEXT_FIELDS = ['pipeline_error_detail', 'description', 'notes', 'summary', 'biosample_summary']
+TEXT_FIELDS = ['pipeline_error_detail', 'description', 'notes']
 
 
 def sorted_pairs_hook(pairs):

--- a/src/snovault/elasticsearch/create_mapping.py
+++ b/src/snovault/elasticsearch/create_mapping.py
@@ -33,8 +33,7 @@ log = logging.getLogger(__name__)
 META_MAPPING = {
     '_all': {
         'enabled': False,
-        'analyzer': 'snovault_index_analyzer',
-        'search_analyzer': 'snovault_search_analyzer'
+        'analyzer': 'snovault_search_analyzer'
     },
     'dynamic_templates': [
         {
@@ -272,8 +271,7 @@ def es_mapping(mapping):
     return {
         '_all': {
             'enabled': True,
-            'analyzer': 'snovault_index_analyzer',
-            'search_analyzer': 'snovault_search_analyzer'
+            'analyzer': 'snovault_search_analyzer'
         },
         'dynamic_templates': [
             {

--- a/src/snovault/helpers/helper.py
+++ b/src/snovault/helpers/helper.py
@@ -162,8 +162,8 @@ def get_search_fields(request, doc_types):
     types = request.registry[TYPES]
     for doc_type in doc_types:
         type_info = types[doc_type]
-        for value in type_info.schema.get('boost_values', ()):
-            fields.add('embedded.' + value)
+        for value, boost in type_info.schema.get('boost_values', {}).items():
+            fields.add('embedded.' + value + '^' + boost)
             highlights['embedded.' + value] = {}
     return list(fields), highlights
 

--- a/src/snovault/helpers/helper.py
+++ b/src/snovault/helpers/helper.py
@@ -157,7 +157,7 @@ def get_search_fields(request, doc_types):
     Returns set of columns that are being searched and highlights
     """
 
-    return {}, {}
+    return set(), {}
 
 
 def list_visible_columns_for_schemas(request, schemas):

--- a/src/snovault/helpers/helper.py
+++ b/src/snovault/helpers/helper.py
@@ -163,7 +163,7 @@ def get_search_fields(request, doc_types):
     for doc_type in doc_types:
         type_info = types[doc_type]
         for value, boost in type_info.schema.get('boost_values', {}).items():
-            fields.add('embedded.' + value + '^' + boost)
+            fields.add('embedded.' + value + '^' + str(boost))
             highlights['embedded.' + value] = {}
     return list(fields), highlights
 

--- a/src/snovault/helpers/helper.py
+++ b/src/snovault/helpers/helper.py
@@ -157,15 +157,7 @@ def get_search_fields(request, doc_types):
     Returns set of columns that are being searched and highlights
     """
 
-    fields = {'uuid', 'unique_keys.*'}
-    highlights = {}
-    types = request.registry[TYPES]
-    for doc_type in doc_types:
-        type_info = types[doc_type]
-        for value, boost in type_info.schema.get('boost_values', {}).items():
-            fields.add('embedded.' + value + '^' + str(boost))
-            highlights['embedded.' + value] = {}
-    return list(fields), highlights
+    return {}, {}
 
 
 def list_visible_columns_for_schemas(request, schemas):

--- a/src/snovault/helpers/helper.py
+++ b/src/snovault/helpers/helper.py
@@ -157,7 +157,7 @@ def get_search_fields(request, doc_types):
     Returns set of columns that are being searched and highlights
     """
 
-    return set(), {}
+    return [], {}
 
 
 def list_visible_columns_for_schemas(request, schemas):

--- a/src/snovault/viewconfigs/searchview.py
+++ b/src/snovault/viewconfigs/searchview.py
@@ -136,7 +136,7 @@ class SearchView(BaseView):  # pylint: disable=too-few-public-methods
             del query['query']['query_string']
         else:
             query['query']['query_string']['fields'].extend(
-                ['_all', '*.uuid', '*.md5sum', '*.submitted_file_name']
+                ['_all']
             )
         set_sort_order(self._request, search_term, types, doc_types, query, result)
         used_filters = set_filters(self._request, query, result)


### PR DESCRIPTION
Improve free-text queries by adding english and word-delimiter analyzers to `_all` and removing ngrams analyzer. Set the default analyzer to use this chain as well. Only search over `_all` field.