### PR TITLE
[SNO-169] Creating a command for admin user creation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
         profile = snowflakes.commands.profile:main
         spreadsheet-to-json = snowflakes.commands.spreadsheet_to_json:main
         migrate-attachments-aws = snowflakes.commands.migrate_attachments_aws:main
+        create-admin-user = snowflakes.commands.create_admin_user:main 
 
         [paste.app_factory]
         main = snowflakes:main

--- a/src/snowflakes/commands/create_admin_user.py
+++ b/src/snowflakes/commands/create_admin_user.py
@@ -1,0 +1,51 @@
+from pyramid.paster import get_app
+import logging
+from webtest import TestApp
+
+EPILOG = __doc__
+
+
+def run(app, first_name, last_name, email, lab):
+    environ = {
+        'HTTP_ACCEPT': 'application/json',
+        'REMOTE_USER': 'TEST',
+    }
+    testapp = TestApp(app, environ)
+    testapp.post_json('/user', {
+        'first_name': first_name,
+        'last_name': last_name,
+        'email': email,
+        'lab': lab,
+        'groups': ['admin']
+    })
+
+
+def main():
+    ''' Creates an admin user '''
+
+    import argparse
+    parser = argparse.ArgumentParser(
+        description="Creates an admin user", epilog=EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument('--first-name', default='Admin', help="First name")
+    parser.add_argument('--last-name', default='Test', help="Last name")
+    parser.add_argument('--email', default='admin_test@example.org', help="E-mail")
+    parser.add_argument('--lab', default='/labs/j-michael-cherry/', help="Lab")
+    parser.add_argument('--app-name', help="Pyramid app name in configfile")
+    parser.add_argument('config_uri', help="path to configfile")
+    args = parser.parse_args()
+
+    logging.basicConfig()
+    options = {
+        'embed_cache.capacity': '5000',
+        'indexer': 'true',
+    }
+    app = get_app(args.config_uri, args.app_name, options)
+
+    logging.getLogger('encoded').setLevel(logging.DEBUG)
+    return run(app, args.first_name, args.last_name, args.email, args.lab)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
https://encodedcc.atlassian.net/browse/SNO-169

Command to create an admin user. Useful for brand new Encoded application that requires an initial admin user to start submitting data to the application.

Usage:
$ bin/create-admin-user --help
usage: create-admin-user [-h] [--first-name FIRST_NAME]
                         [--last-name LAST_NAME] [--email EMAIL] [--lab LAB]
                         [--app-name APP_NAME]
                         config_uri

Creates an admin user

positional arguments:
  config_uri            path to config file

optional arguments:
  -h, --help            show this help message and exit
  --first-name FIRST_NAME
                        First name
  --last-name LAST_NAME
                        Last name
  --email EMAIL         E-mail
  --lab LAB             Lab
  --app-name APP_NAME   Pyramid app name in config file