### PR TITLE
Update README.rst for java version consistency

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ System Installation (OSX Big Sur(testing), Catlina(10.15.x), Mojave(10.14.6))
 
         brew install openjdk@11
         # Add to your PATH in terminal profile, i.e. ~/.bash_profile or ~/.zshrc
-        export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
+        export JAVA_HOME=$(/usr/libexec/java_home -v 11)
 
 9. Elasticsearch 5.x
     .. code-block:: bash


### PR DESCRIPTION
When I was attempting to follow these instructions, I got an error that version 1.8 was not installed and Otto pointed out that it was version 11 that we just installed.  Changing the command to have -v 11 worked.  I am not sure where the 1.8 came from and wondered if possibly it was meant to be 11.8.  This fix has 11.