### PR TITLE
SNO-214-upgrade-node-to-version-12-for-circleci-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ executors:
       - ES_BIN: /usr/share/elasticsearch/bin
       - ES_MAJOR_VERSION: 5
       - PG_VERSION: 11
-      - NODE_VERSION: 10
+      - NODE_VERSION: 12
 
 commands:
   buildout:

--- a/README.rst
+++ b/README.rst
@@ -25,13 +25,11 @@ System Installation (OSX Big Sur(testing), Catlina(10.15.x), Mojave(10.14.6))
         # echo 'export PATH="/usr/local/opt/postgresql@11/bin:$PATH"' >> YOUR_SHELL_PROFILE
 
 5. Node 10.x.x
-    Node 12 is known to work as well.
-
     .. code-block:: bash
 
-        brew install node@10
+        brew install node@12
 
-    You may need to link ``node``/``npm`` with ``brew link node@10`` then add it to your ``PATH``
+    You may need to link ``node``/``npm`` with ``brew link node@12`` then add it to your ``PATH``
 
 6. Ruby - Non system version to install compass while avoiding permission errors
     .. code-block:: bash


### PR DESCRIPTION
Modifications to make CircleCI tests use node 12.