### PR TITLE
SNO-216 Fix dev-servers 100% cpu usage when nothing to print.

### DIFF
--- a/src/snovault/dev_servers.py
+++ b/src/snovault/dev_servers.py
@@ -17,6 +17,7 @@ import shutil
 import sys
 import pdb
 import subprocess
+import time
 
 
 EPILOG = __doc__
@@ -26,8 +27,13 @@ logger = logging.getLogger(__name__)
 
 def print_to_terminal(stdout):
     while True:
+        printed = False
         for line in iter(stdout.readline, b''):
-            sys.stdout.write(line.decode('utf-8'))
+            if line:
+                sys.stdout.write(line.decode('utf-8'))
+                printed = True
+        if not printed:
+            time.sleep(0.1)
 
 def nginx_server_process(prefix='', echo=False):
     args = [

--- a/src/snovault/dev_servers.py
+++ b/src/snovault/dev_servers.py
@@ -39,7 +39,7 @@ def nginx_server_process(prefix='', echo=False):
     args = [
         os.path.join(prefix, 'nginx'),
         '-c', resource_filename('snovault', 'nginx-dev.conf'),
-        '-g', 'daemon off;'
+        '-g', 'daemon off; pid /dev/null;'
     ]
     process = subprocess.Popen(
         args,

--- a/src/snovault/nginx-dev.conf
+++ b/src/snovault/nginx-dev.conf
@@ -5,7 +5,10 @@
 events {
     worker_connections  2048;
 }
+error_log stderr info;
 http {
+    access_log /dev/stdout;
+
     resolver 8.8.8.8;
     upstream app {
         server 127.0.0.1:6543;


### PR DESCRIPTION
Add a 100ms sleep to avoid dev-servers spinning at 100% cpu when it's got nothing to print.